### PR TITLE
Document files in Documentation/ dir

### DIFF
--- a/REST_API/Documentation/README.md
+++ b/REST_API/Documentation/README.md
@@ -1,0 +1,11 @@
+# Content of Documentation/ dir
+## [blueprint.json](blueprint.json)
+File [blueprint.json](blueprint.json) is example of blueprint in json deployment format.
+More info about converting to JSON deployment format can be found in [main documentation](../../README.md)
+
+## [requests.http](requests.http)
+File [requests.http](requests.http) contain sample request for xOpera REST API.
+
+
+## [swagger.json](swagger.json)
+File [swagger.json](swagger.json) contain swagger description of xOpera REST API.


### PR DESCRIPTION
This PR adds README.md file into [Documentation/](https://github.com/SODALITE-EU/xopera-rest-api/tree/master/REST_API/Documentation) dir, that adds descriptions of files in the same directory.