### PR TITLE
add feature: git guest user specification and git documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,17 @@ Implementation of the xOpera orchestrator REST API
     - Docker engine 19.03 or newer
 
 ### GIT backend server (optional, recommended)
-xOpera REST API uses git to store blueprints. It supports github.com and gitlab (both gitlab.com and private gitlab based servers).
+xOpera REST API uses git backend to store blueprints. It supports github.com and gitlab (both gitlab.com and private gitlab based servers).
 If GIT server is not set it uses computer's filesystem to store git repos.
 
 To connect REST API to github.com:
+ - github.com user with enough private repository is needed. Every blueprint will be saved to its own repository,
+  so unlimited account with private repositories is recommended.
  - obtain [github access token](https://github.com/settings/tokens) with repo end delete_repo permissions
  - export following environmental variables:
     - XOPERA_GIT_TYPE=github
     - XOPERA_GIT_AUTH_TOKEN=[your_github_access_token]
+ - optionally set some of [optional git config settings](#Optional-git-configuration-settings)
     
 To connect REST API to gitlab server:
  - obtain [Gitlab's Personal Access Token](https://xxx.xx/profile/personal_access_tokens) with api scope
@@ -23,9 +26,18 @@ To connect REST API to gitlab server:
     - XOPERA_GIT_TYPE=gitlab
     - XOPERA_GIT_URL=[url_to_your_gitlab_server]
     - XOPERA_GIT_AUTH_TOKEN=[your_personal_access_token]
+ - optionally set some of [optional git config settings](#Optional-git-configuration-settings)
 
 
-See [example config](REST_API/Implementation/settings/example_settings.sh).
+#### Optional git configuration settings
+Beside obligatory settings following settings can be configured:
+ - XOPERA_GIT_WORKDIR (default: `/tmp/git_db`) - workdir for git on REST API server
+ - XOPERA_GIT_REPO_PREFIX (default: `gitDB_`) - repo prefix. Blueprint with token `963d7c94-34f9-498d-b122-472dbd9a8681` would be saved to repository `gitDB_963d7c94-34f9-498d-b122-472dbd9a8681`
+ - XOPERA_GIT_COMMIT_NAME (default: `SODALITE-xOpera-REST-API`) - user.name to author git commit
+ - XOPERA_GIT_COMMIT_MAIL (default: `no-email@domain.com`) - user.mail to author git commit
+ - XOPERA_GIT_GUEST_PERMISSIONS (default: `reporter`) - role, assigned to user, added to repository. See [access to blueprints](#ACCESS-TO-REPOSITORY-WITH-BLUEPRINTS).
+
+See [example config](REST_API/Implementation/settings/example_settings.sh) for example on how to export variables.
 ### PostgreSQL (optional, recommended)
 Rest API is using PostgreSQL database for saving bluepints and deployment logs.
 If PostgreSQL database is not available, it uses computer's filesystem.
@@ -133,7 +145,8 @@ Standard scenarios of using REST api:
 ### ACCESS TO REPOSITORY WITH BLUEPRINTS
 - xOpera REST API uses git backend for storing blueprints
 - to obtain access, POST to /manage/<blueprint_token>/user endpoint username
-    - invitation for user with username will be sent to its email address
+    - invitation for user with username will be sent to its email address (github.com)
+    - user will be added to repository (gitlab)
 - with GET to /manage/<blueprint_token>/user user_list can be obtained
 
 ## TOSCA 1.3 Cloud Service Archive (CSAR) format

--- a/REST_API/Implementation/gitCsarDB/__init__.py
+++ b/REST_API/Implementation/gitCsarDB/__init__.py
@@ -16,6 +16,7 @@ def connect(**kwargs):
             f'Unsupported gitCsarDB type, supported: "gitlab", "github", "mock", requested: {kwargs["type"]}')
     try:
         return GitCsarDB(connector=connector, workdir=kwargs['workdir'], repo_prefix=kwargs['repo_prefix'],
-                         commit_name=kwargs['commit_name'], commit_mail=kwargs['commit_mail'])
+                         commit_name=kwargs['commit_name'], commit_mail=kwargs['commit_mail'],
+                         guest_permissions=kwargs['guest_permissions'])
     except KeyError:
         return GitCsarDB(connector=connector)

--- a/REST_API/Implementation/gitCsarDB/connectors.py
+++ b/REST_API/Implementation/gitCsarDB/connectors.py
@@ -51,10 +51,11 @@ class Connector:
         """
         pass
 
-    def add_collaborator(self, repo_name: str, username: str):
+    def add_collaborator(self, repo_name: str, username: str, permissions: str = 'developer'):
         """
         Adds user as collaborator to repository.
         Args:
+            permissions: either developer or reporter. Addapted after gitlab permissions
             repo_name: name of repository
             username: username of user to be added to repo
 
@@ -150,8 +151,7 @@ class MockConnector(Connector):
         repo_path = self.workdir / Path(repo_name)
         return repo_path.exists()
 
-    def add_collaborator(self, repo_name: str, username: str):
-
+    def add_collaborator(self, repo_name: str, username: str, permissions='developer'):
         if repo_name not in self.collaborators:
             return False
         if username in self.collaborators[repo_name]:
@@ -367,9 +367,10 @@ class GithubConnector(Connector):
             return False
         return True
 
-    def add_collaborator(self, repo_name: str, username: str):
+    def add_collaborator(self, repo_name: str, username: str, permissions='developer'):
         repo = self.__get_repo(repo_name)
-        repo.add_to_collaborators(collaborator=username, permission='pull')
+        github_permissions = "push" if permissions == 'developer' else "pull"
+        repo.add_to_collaborators(collaborator=username, permission=github_permissions)
         return True
 
     def get_collaborators(self, repo_name):

--- a/REST_API/Implementation/gitCsarDB/main.py
+++ b/REST_API/Implementation/gitCsarDB/main.py
@@ -16,11 +16,13 @@ class GitCsarDB:
         pass
 
     def __init__(self, connector: Connector, workdir="/tmp/git_db", repo_prefix='gitDB_',
-                 commit_name="SODALITE-xOpera-REST-API", commit_mail="some-email@xlab.si"):
+                 commit_name="SODALITE-xOpera-REST-API", commit_mail="some-email@xlab.si",
+                 guest_permissions="reporter"):
         self.git_connector = connector
         self.workdir = Path(workdir)
         self.workdir.mkdir(exist_ok=True)
         self.repo_prefix = repo_prefix
+        self.guest_permissions = guest_permissions
         self.commit_name = commit_name
         self.commit_mail = commit_mail
 
@@ -96,7 +98,7 @@ class GitCsarDB:
 
     def add_user(self, csar_token: uuid, username: str):
         repo_name = self.repo_name(csar_token)
-        return self.git_connector.add_collaborator(repo_name, username)
+        return self.git_connector.add_collaborator(repo_name, username, permissions=self.guest_permissions)
 
     def get_user_list(self, csar_token: uuid):
         repo_name = self.repo_name(csar_token)

--- a/REST_API/Implementation/run.py
+++ b/REST_API/Implementation/run.py
@@ -280,7 +280,7 @@ class GitUserManage(Resource):
 
         success, error_msg = CSAR_db.add_member_to_blueprint(blueprint_token=blueprint_token, username=username)
         if success:
-            return "invite sent", 201
+            return f"invite for user {username} sent" if Settings.git_config['type'] == 'github' else f"user {username} added", 201
         response = {
             'description': f"Could not add user {username} to repository with blueprint_id '{blueprint_token}'",
             'stacktrace': error_msg

--- a/REST_API/Implementation/settings/example_settings.sh
+++ b/REST_API/Implementation/settings/example_settings.sh
@@ -12,7 +12,8 @@ export XOPERA_GIT_AUTH_TOKEN=authtoken
 export XOPERA_GIT_WORKDIR=/tmp/git_db
 export XOPERA_GIT_REPO_PREFIX=gitDB_
 export XOPERA_GIT_COMMIT_NAME=SODALITE-xOpera-REST-API
-export XOPERA_GIT_COMMIT_MAIL=some-email@domain.com
+export XOPERA_GIT_COMMIT_MAIL=no-email@domain.com
+export XOPERA_GIT_GUEST_PERMISSIONS=reporter
 
 # SQL_database
 export XOPERA_DATABASE_IP=172.17.0.3

--- a/REST_API/Implementation/settings/settings.py
+++ b/REST_API/Implementation/settings/settings.py
@@ -43,7 +43,8 @@ class Settings:
             'workdir': os.getenv("XOPERA_GIT_WORKDIR", "/tmp/git_db"),
             'repo_prefix': os.getenv("XOPERA_GIT_REPO_PREFIX", "gitDB_"),
             'commit_name': os.getenv("XOPERA_GIT_COMMIT_NAME", "SODALITE-xOpera-REST-API"),
-            'commit_mail': os.getenv("XOPERA_GIT_COMMIT_MAIL", "no-email@domain.com")
+            'commit_mail': os.getenv("XOPERA_GIT_COMMIT_MAIL", "no-email@domain.com"),
+            'guest_permissions': os.getenv("XOPERA_GIT_GUEST_PERMISSIONS", "reporter")
         }
 
         Settings.sql_config = {


### PR DESCRIPTION
Every guest git user gets one of two permissions (reporter or developer) on addition to repository. Choice can be made on REST API boot via env_vars.