### PR TITLE
fix bug: arbitrary entry-definitions file

### DIFF
--- a/REST_API/Implementation/blueprint_converters/blueprint2CSAR.py
+++ b/REST_API/Implementation/blueprint_converters/blueprint2CSAR.py
@@ -228,6 +228,31 @@ def validate_csar(csar: Path, raise_exceptions=False):
     return True
 
 
+def entry_definitions(csar: Path):
+    """
+    returns path: str to entry definitions, relative to csar path
+
+    """
+
+    tosca_meta_path = Path(csar / 'TOSCA-Metadata' / 'TOSCA.meta')
+
+    if not tosca_meta_path.exists():
+        yaml_files = glob.glob(str(csar) + "/*.yaml") + glob.glob(str(csar) + "/*.yml")
+
+        if len(yaml_files) != 1:
+            return None
+
+        return Path(yaml_files[0]).name
+
+    else:
+        metadata_yaml = yaml.safe_load(open(tosca_meta_path, 'r').read())
+
+        if 'Entry-Definitions' not in metadata_yaml:
+            return None
+
+        return metadata_yaml['Entry-Definitions']
+
+
 def main(args):
     to_CSAR(blueprint_name=args.name, blueprint_dir=args.blueprint_dir, no_meta=args.no_meta,
             entry_definitions=args.entry_definitions, other_definitions=args.other_definitions,

--- a/REST_API/Implementation/service/deploy_scripts/deploy.sh
+++ b/REST_API/Implementation/service/deploy_scripts/deploy.sh
@@ -5,6 +5,7 @@ logfile="$2"
 timestamp_start="$3"
 inputs_file="$4"
 interpreter="$5"
+entry_definitions="$6"
 
 eval "$(ssh-agent)" >>"/dev/null"
 cd "${0%/*}/../.." || exit
@@ -19,10 +20,10 @@ echo "Launching xOpera"
 
 if [ -z "$inputs_file" ]
 then
-    opera deploy service.yaml
+    opera deploy "$entry_definitions"
 
 else
-    opera deploy -i "$inputs_file" service.yaml
+    opera deploy -i "$inputs_file" "$entry_definitions"
 fi
 
 echo $?

--- a/REST_API/Implementation/service/xopera_service.py
+++ b/REST_API/Implementation/service/xopera_service.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import yaml
 from werkzeug.datastructures import FileStorage
 
+from blueprint_converters import blueprint2CSAR
 from settings import Settings
 from util import xopera_util, timestamp_util
 
@@ -18,6 +19,7 @@ def deploy(deployment_location: Path, inputs_file: FileStorage = None):
     log.info("Orchestrating with xOpera...")
 
     timestamp_start = timestamp_util.datetime_now_to_string()
+    entry_definitions = blueprint2CSAR.entry_definitions(csar=deployment_location)
 
     inputs_dict = dict()
     inputs_filename = "inputs.yaml"
@@ -40,7 +42,7 @@ def deploy(deployment_location: Path, inputs_file: FileStorage = None):
         yaml.dump(inputs_dict, inputs_file)
 
     _list = [f'{Settings.implementation_dir}/service/deploy_scripts/deploy.sh', '{}'.format(str(deployment_location)),
-             Settings.logfile_name, timestamp_start, inputs_filename, Settings.interpreter]
+             Settings.logfile_name, timestamp_start, inputs_filename, Settings.interpreter, entry_definitions]
 
     subprocess.Popen(_list)
 


### PR DESCRIPTION
This PR fixes bug and enables xOpera REST API to deploy TOSCA template with entry-definitions file, different than service.yaml in TOSCA root dir.

Closes #19