### PR TITLE
Enhancement: add commit_sha and minor-major version_tag

### DIFF
--- a/REST_API/Implementation/finalize_deployment.py
+++ b/REST_API/Implementation/finalize_deployment.py
@@ -75,8 +75,11 @@ def main():
 
     # save deployment data to database
     revision_msg = git_util.after_job_commit_msg(token=blueprint_token, mode=mode)
+    version_tag = xopera_util.read_version_tag(deploy_location=deploy_location)
+    if version_tag == 'None':
+        version_tag = CSAR_db.get_tags(blueprint_token=blueprint_token)[-1]
     result, _ = CSAR_db.add_revision(blueprint_token=blueprint_token, blueprint_path=deploy_location,
-                                     revision_msg=revision_msg)
+                                     revision_msg=revision_msg, minor_to_increment=version_tag)
 
     # register adding revision
     SQL_database.save_git_transaction_data(blueprint_token=result['blueprint_token'],
@@ -84,7 +87,8 @@ def main():
                                            revision_msg=revision_msg,
                                            job='update',
                                            git_backend=str(CSAR_db.connection.git_connector),
-                                           repo_url=result['url'])
+                                           repo_url=result['url'],
+                                           commit_sha=result['commit_sha'])
 
     shutil.rmtree(deploy_location)
     os.mkdir(deploy_location)

--- a/REST_API/Implementation/gitCsarDB/tag_util.py
+++ b/REST_API/Implementation/gitCsarDB/tag_util.py
@@ -1,0 +1,69 @@
+
+
+def decode_tag(tag: str):
+    """
+    transform tag: str to tag: tuple
+    'v1.1' -> (1,1)
+    'v1' -> (1,0)
+    """
+    tag_parsed = tag[1:].split('.')
+    if len(tag_parsed) == 1:
+        tag_parsed.append(0)
+    return int(tag_parsed[0]), int(tag_parsed[1])
+
+
+def encode_tag(tag: tuple):
+    """
+    converts tag back to string
+    (1,1) -> 'v1.1'
+    (1,0) -> 'v1.0'
+    """
+    return f'v{tag[0]}.{tag[1]}'
+
+
+def parse_tags(tags):
+    """
+    transforms list of tags (in string format or git.refs.tag.TagReference) to sorted list of tuples
+    """
+
+    tags_str = [str(tag) for tag in tags]
+    tags_parsed = [decode_tag(tag) for tag in tags_str]
+    tags_sorted = sorted(tags_parsed, key=lambda x: (x[0], x[1]))
+    return tags_sorted
+
+
+def next_major(tags: list, return_tuple=False):
+    """
+    returns next tag: tuple or str with incremented major version
+    """
+    tags_tuples = parse_tags(tags)
+    tags_sorted = sorted(tags_tuples, key=lambda x: (x[0], x[1]))
+    if not tags_sorted:
+        next_tag_tuple = 1, 0
+    else:
+        next_tag_tuple = tags_sorted[-1][0]+1, 0
+
+    if return_tuple:
+        return next_tag_tuple
+
+    return encode_tag(next_tag_tuple)
+
+
+def next_minor(tags: list, tag: str, return_tuple=False):
+    """
+    returns next tag: tuple or str with incremented minor version, relative to tag
+    """
+    tags_tuples = parse_tags(tags)
+    tag_chosen = decode_tag(tag)
+    if not tags_tuples:
+        next_tag_tuple = 1, 0
+    elif tag_chosen not in tags_tuples:
+        next_tag_tuple = tag_chosen
+    else:
+        minor_versions = sorted([int(tag_tuple[1]) for tag_tuple in tags_tuples if tag_tuple[0] == tag_chosen[0]])
+        next_tag_tuple = tag_chosen[0], max(minor_versions) + 1
+
+    if return_tuple:
+        return next_tag_tuple
+
+    return encode_tag(next_tag_tuple)

--- a/REST_API/Implementation/run.py
+++ b/REST_API/Implementation/run.py
@@ -249,6 +249,8 @@ class Deploy(Resource):
             return {"message": 'Did not find blueprint with token: {} and version_id: {} '.format(
                 blueprint_token, version_tag or 'any')}, 404
 
+        xopera_util.save_version_tag(deploy_location=location, version_tag=version_tag)
+
         xopera_service.deploy(deployment_location=location, inputs_file=file)
 
         log.info("Deploying '{}', session_token: {}".format(blueprint_token, session_token))
@@ -285,6 +287,8 @@ class Deploy(Resource):
             if git_util.after_job_commit_msg(token=blueprint_token, mode='deploy') not in last_message:
                 return {"message": f"Blueprint with token: {blueprint_token}, and version_tag: {version_tag or 'any'} "
                                    f"has not been deployed yet, cannot undeploy"}, 403
+
+        xopera_util.save_version_tag(deploy_location=location, version_tag=version_tag)
 
         xopera_service.undeploy(deployment_location=location, inputs_file=file)
 
@@ -456,7 +460,8 @@ class ManageCsar(Resource):
                                                revision_msg=f"Updated blueprint: {message}",
                                                job='update',
                                                git_backend=str(CSAR_db.connection.git_connector),
-                                               repo_url=result['url'])
+                                               repo_url=result['url'],
+                                               commit_sha=result['commit_sha'])
 
         return result, 200
 
@@ -481,7 +486,8 @@ class NewBlueprintCsar(Resource):
                                                revision_msg=f"Saved new blueprint: {message}",
                                                job='update',
                                                git_backend=str(CSAR_db.connection.git_connector),
-                                               repo_url=result['url'])
+                                               repo_url=result['url'],
+                                               commit_sha=result['commit_sha'])
 
         return result, 200
 

--- a/REST_API/Implementation/tests/test_02_tag_util.py
+++ b/REST_API/Implementation/tests/test_02_tag_util.py
@@ -1,0 +1,36 @@
+from assertpy import assert_that
+
+from gitCsarDB import tag_util
+
+
+def test_encode_tag():
+    assert_that(tag_util.encode_tag((1, 0))).is_equal_to('v1.0')
+    assert_that(tag_util.encode_tag((5, 2))).is_equal_to('v5.2')
+
+
+def test_decode_tag():
+    assert_that(tag_util.decode_tag('v1.1')).is_equal_to((1, 1))
+    assert_that(tag_util.decode_tag('v1')).is_equal_to((1, 0))
+    assert_that(tag_util.decode_tag('v1.42')).is_equal_to((1, 42))
+
+
+def test_parse_tags():
+    tags = ['v5.1', 'v3.2', 'v3.1', 'v5.2', 'v1', 'v1.1']
+    expected = [(1, 0), (1, 1), (3, 1), (3, 2), (5, 1), (5, 2)]
+    assert_that(tag_util.parse_tags(tags)).is_equal_to(expected)
+
+
+def test_next_major():
+    assert_that(tag_util.next_major([])).is_equal_to('v1.0')
+    tags = ['v5.1', 'v3.2', 'v3.1', 'v5.2', 'v1', 'v1.1']
+    assert_that(tag_util.next_major(tags)).is_equal_to('v6.0')
+    assert_that(tag_util.next_major(tags, return_tuple=True)).is_equal_to((6, 0))
+
+
+def test_next_minor():
+    assert_that(tag_util.next_minor([], 'v5.1')).is_equal_to('v1.0')
+    tags = ['v5.1', 'v3.2', 'v3.1', 'v5.2', 'v1', 'v1.1']
+    assert_that(tag_util.next_minor(tags, 'v5.1')).is_equal_to('v5.3')
+    assert_that(tag_util.next_minor(tags, 'v5.2')).is_equal_to('v5.3')
+    assert_that(tag_util.next_minor(tags, 'v42')).is_equal_to('v42.0')
+    assert_that(tag_util.next_minor(tags, 'v5.1', return_tuple=True)).is_equal_to((5, 3))

--- a/REST_API/Implementation/tests/test_03_gitCsarDB.py
+++ b/REST_API/Implementation/tests/test_03_gitCsarDB.py
@@ -68,7 +68,7 @@ def test_save_update_CSAR(db: GitCsarDB, generic_dir: Path):
     assert db.CSAR_exists(csar_token), "Did not correctly saved repo, test useless"
     db.save_CSAR(csar_path=generic_dir, csar_token=csar_token)
 
-    repo_path = db.get_CSAR(csar_token=csar_token, version_tag='v2')
+    repo_path = db.get_CSAR(csar_token=csar_token, version_tag='v2.0')
     assert len([file for file in repo_path.glob("[!.git]*")]) > 0, "Repo empty"
 
 

--- a/REST_API/Implementation/tests/test_04_manage.py
+++ b/REST_API/Implementation/tests/test_04_manage.py
@@ -25,13 +25,13 @@ class TestPostNew:
         resp = client.post("/manage", data=csar_1)
         assert_that(resp.status_code).is_equal_to(200)
         assert_that(resp.json).is_not_none().contains_only("message", 'blueprint_token', 'url',
-                                                           'version_tag', 'users')
+                                                           'version_tag', 'users', 'commit_sha')
         try:
             uuid.UUID(resp.get_json()['blueprint_token'])
         except ValueError:
             fail('"blueprint_token" from response is not uuid')
 
-        assert_that(resp.get_json()['version_tag']).is_equal_to('v1')
+        assert_that(resp.get_json()['version_tag']).is_equal_to('v1.0')
 
         try:
             validators.url(resp.get_json()['url'])
@@ -65,8 +65,8 @@ class TestPostMultipleVersions:
         resp2 = client.post(f"/manage/{token}", data=csar_2)
         assert_that(resp2.status_code).is_equal_to(200)
         assert_that(resp2.json).is_not_none().contains_only("message", 'blueprint_token', 'url',
-                                                            'version_tag', 'users')
-        assert_that(resp2.json['version_tag']).is_equal_to('v2')
+                                                            'version_tag', 'users', 'commit_sha')
+        assert_that(resp2.json['version_tag']).is_equal_to('v2.0')
 
 
 class TestDelete:

--- a/REST_API/Implementation/util/xopera_util.py
+++ b/REST_API/Implementation/util/xopera_util.py
@@ -128,3 +128,14 @@ def parse_log(deploy_location: Path):
         state = "failed" if len([i for i in failed_keywords if i in log_str]) != 0 else "done"
 
     return state, log_str
+
+
+def save_version_tag(deploy_location: Path, version_tag: str):
+    with (deploy_location / "version_tag").open('w') as file:
+        file.write(str(version_tag))
+
+
+def read_version_tag(deploy_location: Path):
+    version_tag = (deploy_location / "version_tag").open('r').read()
+    (deploy_location / "version_tag").unlink()
+    return version_tag

--- a/REST_API/requirements.txt
+++ b/REST_API/requirements.txt
@@ -31,7 +31,7 @@ more-itertools==8.2.0
 munch==2.5.0
 netifaces==0.10.9
 openstacksdk==0.41.0
-opera==0.5.5
+opera==0.5.6
 os-service-types==1.7.0
 packaging==20.1
 pbr==5.4.4


### PR DESCRIPTION
This commit enhances git metadata, saved in git_log table of SQL database.
Since tags can be deleted, commit_sha introduces more permanent connection between database entry and git object it tries to log.
Until now, version tag did not differentiate between real versions of blueprint (modified by user) and metadata updates (modified by xOpera REST API). Now that, real versions differentiate by major tag version and metadata changes get only new minor version, tracking changes can be much easier.

Resolves #20 