### PR TITLE
fix copy of rc files openstack_setup.sh

### DIFF
--- a/REST_API/Installation/openstack_setup.sh
+++ b/REST_API/Installation/openstack_setup.sh
@@ -12,11 +12,11 @@ fi
 echo "OpenStack RC file location: ${rc_file_location}"
 
 echo "Copying OpenStack RC file to settings..."
-cp "$file" "Implementation/settings/openrc.sh" || exit
+cp "$file" "../Implementation/settings/openrc.sh" || exit
 echo "done"
 
 
-cd Implementation || exit
+cd ../Implementation || exit
 rm -rf settings/vault.yml || true
 
 read -s -r -p "Enter OpenStack RC password:" os_password


### PR DESCRIPTION
Copy to Implementation/settings/openrc.sh does not work, since the first "cd" changes to Installation directory.