### PR TITLE
add xopera- prefix to container names

### DIFF
--- a/REST_API/app.conf
+++ b/REST_API/app.conf
@@ -7,7 +7,7 @@ server {
     location / { try_files $uri @app; }
     location @app {
         include uwsgi_params;
-        uwsgi_pass flask:5000;
+        uwsgi_pass xopera-flask:5000;
     }
 }
 
@@ -24,7 +24,7 @@ server {
     location / { try_files $uri @app; }
     location @app {
         include uwsgi_params;
-        uwsgi_pass flask:5000;
+        uwsgi_pass xopera-flask:5000;
     }
 
 }

--- a/REST_API/docker-compose.yml
+++ b/REST_API/docker-compose.yml
@@ -3,13 +3,13 @@
 version: '3'
 services:
 
-  flask:
+  xopera-flask:
     image: xopera-flask
     build:
       context: .
       dockerfile: Dockerfile-flask
     depends_on:
-      - postgres
+      - xopera-postgres
     volumes:
       - "./Implementation:/usr/local/xopera_rest/Implementation"
       - "/var/run/docker.sock:/var/run/docker.sock"
@@ -20,13 +20,13 @@ services:
       - XOPERA_GIT_URL=https://gitlab.com
       - XOPERA_GIT_AUTH_TOKEN=[your access token here]
       - XOPERA_VERBOSE_MODE=debug
-      - XOPERA_DATABASE_IP=postgres
+      - XOPERA_DATABASE_IP=xopera-postgres
       - XOPERA_DATABASE_NAME=postgres
       - XOPERA_DATABASE_USER=postgres
       - XOPERA_DATABASE_PASSWORD=password
 
 
-  nginx:
+  xopera-nginx:
     image: xopera-nginx
     build:
       context: .
@@ -35,12 +35,12 @@ services:
       - 5000:80
       - 443:443
     depends_on:
-      - flask
-      - postgres
+      - xopera-flask
+      - xopera-postgres
     volumes:
       - "/home/xopera/certs:/etc/nginx/certs"
 
-  postgres:
+  xopera-postgres:
     image: postgres
     environment:
       - POSTGRES_USER=postgres

--- a/xOpera-rest-blueprint/service.yaml
+++ b/xOpera-rest-blueprint/service.yaml
@@ -692,7 +692,7 @@ topology_template:
         volumes:
           - "/home/postgres:/var/lib/postgresql/data"
         ports: ['5432:5432']
-        alias: postgres
+        alias: xopera-postgres
         env_file: /tmp/postgres/postgres.env
       requirements:
         - host:  xOpera-docker-host
@@ -725,7 +725,7 @@ topology_template:
           - "/var/run/docker.sock:/var/run/docker.sock"
           - "/root/.ssh/:/root/.ssh/"
           - "/home/xopera/certs:/home/xopera/certs"
-        alias: flask
+        alias: xopera-flask
       requirements:
         - host:  xOpera-docker-host
         - network: xOpera-docker-network
@@ -740,7 +740,7 @@ topology_template:
         exposed_ports:  ['443', '5000']
         volumes:
           - "/home/xopera/certs:/etc/nginx/certs"
-        alias: nginx
+        alias: xopera-nginx
       requirements:
         - host:  xOpera-docker-host
         - dependency: xOpera-flask


### PR DESCRIPTION
This PR renames containers to xopera-<old-container-name> in order to differentiate components for different services if deployed to the same docker network.