### PR TITLE
Fixed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ To connect REST API to gitlab server:
     - XOPERA_GIT_URL=[url_to_your_gitlab_server]
     - XOPERA_GIT_AUTH_TOKEN=[your_personal_access_token]
  - optionally set some of [optional git config settings](#Optional-git-configuration-settings)
+ 
+ If non of options above is available, xOpera REST API can use its internal filesystem as git server (MockConnector).
+ This option has a big limitation of not enabling users to inspect blueprints as on github.com, gitlab.com or any other gitlab server.
+ To connect REST API with MockConnector to internal filesystem:
+ - export following environmental variables:
+    - XOPERA_GIT_TYPE=mock
+ - optionally set some of [optional git config settings](#Optional-git-configuration-settings)
+ 
+ Note: Mock connector is default option which is used in case of missing XOPERA_GIT_TYPE environmental variable.
 
 
 #### Optional git configuration settings


### PR DESCRIPTION
This PR clarifies the usage of gitCsarDB with MockConnector.

Closes #29 