### PR TITLE
Hardcoded postgres version 13

### DIFF
--- a/xOpera-rest-blueprint/service.yaml
+++ b/xOpera-rest-blueprint/service.yaml
@@ -147,7 +147,7 @@ topology_template:
     xopera-postgres-container:
       type: sodalite.nodes.DockerizedComponent
       properties:
-        image_name: library/postgres:latest
+        image_name: library/postgres:13
         volumes:
           - "/home/postgres:/var/lib/postgresql/data"
         ports: ['5432:5432']


### PR DESCRIPTION
This PR sets targeted docker image for PostgreSQL to postgres:13.

Until this commit, xOpera-rest-blueprint targeted `postgres:latest` image. Last month PostgreSQL released [new major version](https://www.postgresql.org/docs/13/release-13.html), which made postgres container fail during our Continuous Deployment pipeline (pg_data are incompatible among different major versions).

It is recognized that major upgrade and data migration is a necessary step, but it is better to do it manually in a controlled way, not in a hurry when production suddenly fails.

