### PR TITLE
Add kubernetes deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,29 @@ CMD ["-m", "opera.api.cli"]
 
 COPY requirements.txt requirements.yml /app/
 
+ARG HELM_VERSION=3.4.0
+ARG KUBECTL_VERSION=1.20.0
+ENV BASE_URL=https://get.helm.sh
+ENV TAR_FILE=helm-v${HELM_VERSION}-linux-amd64.tar.gz
+
+# install kubectl
+RUN apk add --update --no-cache curl \
+    && curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
+    && mv kubectl /usr/bin/kubectl \
+    && chmod +x /usr/bin/kubectl \
+    && apk del curl \
+    && rm -f /var/cache/apk/*
+
+
+# install helm
+RUN apk add --update --no-cache curl ca-certificates bash git \
+    && curl -L ${BASE_URL}/${TAR_FILE} |tar xvz \
+    && mv linux-amd64/helm /usr/bin/helm \
+    && chmod +x /usr/bin/helm \
+    && rm -rf linux-amd64 \
+    && apk del curl \
+    && rm -f /var/cache/apk/*
+
 RUN export BUILD_PREREQS="gcc musl-dev libffi-dev openssl-dev python3-dev postgresql-dev" \
     && export PACKAGES="git bash openssh-client libpq" \
     && apk add --no-cache $PACKAGES $BUILD_PREREQS \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,8 @@
 opera==0.6.2
 openstacksdk==0.52.0
+openshift==0.11.2
 
-connexion >= 2.7.0; python_version>="3.6"
-connexion >= 2.3.0; python_version=="3.5"
-connexion >= 2.3.0; python_version=="3.4"
-connexion == 2.4.0; python_version<="2.7"
+connexion >= 2.7.0;
 python-dateutil >= 2.8.1
 tornado==6.1
 

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,3 +3,9 @@ roles:
   - src: geerlingguy.docker
   - src: geerlingguy.pip
   - src: geerlingguy.repo-epel
+
+
+
+collections:
+  - name: community.kubernetes
+    version: 1.1.1

--- a/xOpera-rest-blueprint/prerequisites.sh
+++ b/xOpera-rest-blueprint/prerequisites.sh
@@ -39,7 +39,9 @@ fi
 
 echo
 echo "Installing required Ansible roles"
-ansible-galaxy install -r ../requirements.yml --force
+ansible-galaxy install geerlingguy.docker --force
+ansible-galaxy install geerlingguy.pip --force
+ansible-galaxy install geerlingguy.repo-epel --force
 
 echo
 echo "Cloning modules"


### PR DESCRIPTION
This PR adds dependencies for Kubernetes, described in #56.

All components are pinned to current stable release (except helm) and need to be bumped manually in the future.

community.kubernetes collection: 1.1.1
openshift: 0.11.2
helm: 3.4.0
kubectl: 1.20.0

Dockerfile implementation for installation of helm and kubectl is derived from [alpine/k8s:1.14.9](https://hub.docker.com/layers/alpine/k8s/1.14.9/images/sha256-0762cf68638844458b00058d227b4585de339db9211a3c56d06e215d07bf7022?context=explore)

Resolves #56.