### PR TITLE
Outputs and validate commands

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       LOG_LEVEL: debug
       XOPERA_GIT_TYPE: gitlab
       XOPERA_GIT_URL: https://gitlab.com
-      XOPERA_GIT_AUTH_TOKEN: c2hSyLQxTos53xKdnxvY
+      XOPERA_GIT_AUTH_TOKEN: [your access token here]
       XOPERA_DATABASE_IP: postgres
       XOPERA_DATABASE_NAME: postgres
       XOPERA_DATABASE_USER: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       LOG_LEVEL: debug
       XOPERA_GIT_TYPE: gitlab
       XOPERA_GIT_URL: https://gitlab.com
-      XOPERA_GIT_AUTH_TOKEN: [your access token here]
+      XOPERA_GIT_AUTH_TOKEN: c2hSyLQxTos53xKdnxvY
       XOPERA_DATABASE_IP: postgres
       XOPERA_DATABASE_NAME: postgres
       XOPERA_DATABASE_USER: postgres

--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -27,7 +27,85 @@ tags:
   description: Update the deployed TOSCA service template and redeploy it according to the discovered template diff
 - name: info
   description: Information about deployment
+- name: validate
+  description: validate TOSCA service template
+- name: outputs
+  description: Obtain outputs from TOSCA deployed instance
 paths:
+  /outputs/{session_token}:
+    get:
+      tags:
+      - outputs
+      operationId: get_outputs
+      parameters:
+      - name: session_token
+        in: path
+        description: Token of TOSCA session
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/just_message'
+        404:
+          description: Did not find session
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/just_message'
+  /validate/{blueprint_token}:
+    post:
+      tags:
+      - validate
+      operationId: post_validate
+      description: Validates TOSCA service template
+      parameters:
+      - name: blueprint_token
+        in: path
+        description: Token of TOSCA blueprint
+        required: true
+        schema:
+          type: string
+      - name: version_tag
+        in: query
+        description: Version_tag to of TOSCA blueprint
+        schema:
+          type: string
+
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                inputs_file:
+                  type: string
+                  description: File with inputs TOSCA blueprint
+                  format: binary
+      responses:
+        200:
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/just_message'
+        404:
+          description: Did not find blueprint
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/just_message'
+        500:
+          description: Fail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error_msg'
+
   /diff/{session_token}:
     post:
       tags:

--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -50,7 +50,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/just_message'
+                type: object
         404:
           description: Did not find session
           content:

--- a/src/opera/api/blueprint_converters/blueprint2CSAR.py
+++ b/src/opera/api/blueprint_converters/blueprint2CSAR.py
@@ -6,6 +6,7 @@ import sys
 import uuid
 from datetime import datetime
 from pathlib import Path
+import tempfile
 
 import yaml
 
@@ -57,7 +58,7 @@ def to_CSAR_simple(src: Path, dst: Path, raise_exceptions=False):
 
 def to_CSAR(blueprint_name: str, blueprint_dir: Path, no_meta: bool = False, entry_definitions: Path = None,
             other_definitions: list = None, author: str = 'SODALITE blueprint2CSAR tool', output: Path = None,
-            workdir: Path = Path('/tmp/blueprint2csar')):
+            workdir: Path = Path(tempfile.mkdtemp())):
     """
     Packs TOSCA Simple Profile definitions along with all accompanying artifacts
     (e.g. scripts, binaries, configuration files) in TOSCA Cloud Service Archive (CSAR) format.

--- a/src/opera/api/cli.py
+++ b/src/opera/api/cli.py
@@ -4,12 +4,15 @@ import connexion
 
 from opera.api.log import get_logger
 from opera.api.openapi import encoder
+from opera.api.service import sqldb_service, csardb_service
 from opera.api.settings import Settings
 from opera.api.util import xopera_util
 
 DEBUG = os.getenv("DEBUG", "false") == "true"
 logger = get_logger(__name__)
 Settings.load_settings()
+CSAR_db = csardb_service.GitDB(**Settings.git_config)
+SQL_database = sqldb_service.connect(Settings.sql_config)
 
 
 def main():

--- a/src/opera/api/controllers/deploy_controller.py
+++ b/src/opera/api/controllers/deploy_controller.py
@@ -1,15 +1,12 @@
+from opera.api.cli import CSAR_db, SQL_database
 from opera.api.controllers.background_invocation import InvocationService
 from opera.api.log import get_logger
 from opera.api.openapi.models import OperationType, Invocation
 from opera.api.openapi.models.just_message import JustMessage
-from opera.api.service import csardb_service, sqldb_service
-from opera.api.settings import Settings
 from opera.api.util import xopera_util
 
 logger = get_logger(__name__)
 
-CSAR_db = csardb_service.GitDB(**Settings.git_config)
-SQL_database = sqldb_service.connect(Settings.sql_config)
 invocation_service = InvocationService()
 
 

--- a/src/opera/api/controllers/diff_controller.py
+++ b/src/opera/api/controllers/diff_controller.py
@@ -1,12 +1,8 @@
+from opera.api.cli import CSAR_db, SQL_database
 from opera.api.controllers.background_invocation import InvocationWorkerProcess
 from opera.api.openapi.models import Invocation
 from opera.api.openapi.models.just_message import JustMessage
-from opera.api.service import csardb_service, sqldb_service
-from opera.api.settings import Settings
 from opera.api.util import xopera_util
-
-CSAR_db = csardb_service.GitDB(**Settings.git_config)
-SQL_database = sqldb_service.connect(Settings.sql_config)
 
 
 def post_diff(session_token, blueprint_token, version_tag=None):

--- a/src/opera/api/controllers/info_controller.py
+++ b/src/opera/api/controllers/info_controller.py
@@ -1,16 +1,13 @@
 import json
 
+from opera.api.cli import SQL_database
 from opera.api.controllers.background_invocation import InvocationService
 from opera.api.log import get_logger
 from opera.api.openapi.models import InvocationState, Invocation, GitLog
 from opera.api.openapi.models.just_message import JustMessage
-from opera.api.service import csardb_service, sqldb_service
-from opera.api.settings import Settings
 
 logger = get_logger(__name__)
 
-CSAR_db = csardb_service.GitDB(**Settings.git_config)
-SQL_database = sqldb_service.connect(Settings.sql_config)
 invocation_service = InvocationService()
 
 

--- a/src/opera/api/controllers/manage_controller.py
+++ b/src/opera/api/controllers/manage_controller.py
@@ -1,19 +1,16 @@
 import connexion
 
+from opera.api.cli import CSAR_db, SQL_database
 from opera.api.log import get_logger
 from opera.api.openapi.models.collaborators_list import CollaboratorsList
 from opera.api.openapi.models.delete_metadata import DeleteMetadata
 from opera.api.openapi.models.error_msg import ErrorMsg
 from opera.api.openapi.models.git_revision_metadata import GitRevisionMetadata
 from opera.api.openapi.models.just_message import JustMessage
-from opera.api.service import csardb_service, sqldb_service
 from opera.api.settings import Settings
 from opera.api.util import git_util
 
 logger = get_logger(__name__)
-
-CSAR_db = csardb_service.GitDB(**Settings.git_config)
-SQL_database = sqldb_service.connect(Settings.sql_config)
 
 
 def delete_manage_csar(blueprint_token, version_tag=None, force=None):

--- a/src/opera/api/controllers/outputs_controller.py
+++ b/src/opera/api/controllers/outputs_controller.py
@@ -1,14 +1,28 @@
-from opera.api.openapi.models.just_message import JustMessage  # noqa: E501
+from opera.api.cli import SQL_database
+from opera.api.controllers.background_invocation import InvocationWorkerProcess
+from opera.api.log import get_logger
+from opera.api.openapi.models.error_msg import ErrorMsg
+from opera.api.openapi.models.just_message import JustMessage
+from opera.api.util import xopera_util
+
+logger = get_logger(__name__)
 
 
-def get_outputs(session_token):  # noqa: E501
-    """get_outputs
+def get_outputs(session_token):
+    """
+    Obtain outputs
 
-     # noqa: E501
 
     :param session_token: Token of TOSCA session
     :type session_token: str
 
-    :rtype: JustMessage
+    :rtype: object
     """
-    return 'do some magic!'
+
+    if not SQL_database.get_session_data(session_token):
+        return JustMessage(f"Session with session_token: {session_token} does not exist, cannot update"), 404
+
+    outputs, exception = InvocationWorkerProcess.outputs(session_token)
+    if exception:
+        return ErrorMsg(exception[0], exception[1]), 500
+    return outputs, 200

--- a/src/opera/api/controllers/outputs_controller.py
+++ b/src/opera/api/controllers/outputs_controller.py
@@ -1,4 +1,4 @@
-from opera.api.cli import SQL_database
+from opera.api.cli import SQL_database, CSAR_db
 from opera.api.controllers.background_invocation import InvocationWorkerProcess
 from opera.api.log import get_logger
 from opera.api.openapi.models.error_msg import ErrorMsg
@@ -19,8 +19,14 @@ def get_outputs(session_token):
     :rtype: object
     """
 
-    if not SQL_database.get_session_data(session_token):
-        return JustMessage(f"Session with session_token: {session_token} does not exist, cannot update"), 404
+    session_data = SQL_database.get_session_data(session_token)
+    if not session_data:
+        return JustMessage(f"Session with session_token: {session_token} does not exist, cannot deploy"), 404
+    blueprint_token = session_data['blueprint_token']
+    version_tag = session_data['version_tag']
+    if not CSAR_db.version_exists(blueprint_token, version_tag):
+        return JustMessage(
+            f"Did not find blueprint with token: {blueprint_token} and version_id: {version_tag or 'any'}"), 404
 
     outputs, exception = InvocationWorkerProcess.outputs(session_token)
     if exception:

--- a/src/opera/api/controllers/outputs_controller.py
+++ b/src/opera/api/controllers/outputs_controller.py
@@ -1,0 +1,14 @@
+from opera.api.openapi.models.just_message import JustMessage  # noqa: E501
+
+
+def get_outputs(session_token):  # noqa: E501
+    """get_outputs
+
+     # noqa: E501
+
+    :param session_token: Token of TOSCA session
+    :type session_token: str
+
+    :rtype: JustMessage
+    """
+    return 'do some magic!'

--- a/src/opera/api/controllers/undeploy_controller.py
+++ b/src/opera/api/controllers/undeploy_controller.py
@@ -1,15 +1,11 @@
+from opera.api.cli import CSAR_db, SQL_database
 from opera.api.controllers.background_invocation import InvocationService
 from opera.api.log import get_logger
 from opera.api.openapi.models import OperationType, Invocation
 from opera.api.openapi.models.just_message import JustMessage
-from opera.api.service import csardb_service, sqldb_service
-from opera.api.settings import Settings
 from opera.api.util import xopera_util
 
 logger = get_logger(__name__)
-
-CSAR_db = csardb_service.GitDB(**Settings.git_config)
-SQL_database = sqldb_service.connect(Settings.sql_config)
 invocation_service = InvocationService()
 
 

--- a/src/opera/api/controllers/update_controller.py
+++ b/src/opera/api/controllers/update_controller.py
@@ -1,15 +1,11 @@
+from opera.api.cli import CSAR_db, SQL_database
 from opera.api.controllers.background_invocation import InvocationService
 from opera.api.log import get_logger
 from opera.api.openapi.models import OperationType, Invocation
 from opera.api.openapi.models.just_message import JustMessage
-from opera.api.service import csardb_service, sqldb_service
-from opera.api.settings import Settings
 from opera.api.util import xopera_util
 
 logger = get_logger(__name__)
-
-CSAR_db = csardb_service.GitDB(**Settings.git_config)
-SQL_database = sqldb_service.connect(Settings.sql_config)
 invocation_service = InvocationService()
 
 

--- a/src/opera/api/controllers/validate_controller.py
+++ b/src/opera/api/controllers/validate_controller.py
@@ -1,8 +1,8 @@
 from opera.api.cli import CSAR_db
 from opera.api.controllers.background_invocation import InvocationWorkerProcess
 from opera.api.log import get_logger
-from opera.api.openapi.models.error_msg import ErrorMsg  # noqa: E501
-from opera.api.openapi.models.just_message import JustMessage  # noqa: E501
+from opera.api.openapi.models.error_msg import ErrorMsg
+from opera.api.openapi.models.just_message import JustMessage
 from opera.api.util import xopera_util
 
 logger = get_logger(__name__)

--- a/src/opera/api/controllers/validate_controller.py
+++ b/src/opera/api/controllers/validate_controller.py
@@ -1,0 +1,32 @@
+from opera.api.cli import CSAR_db
+from opera.api.controllers.background_invocation import InvocationWorkerProcess
+from opera.api.log import get_logger
+from opera.api.openapi.models.error_msg import ErrorMsg  # noqa: E501
+from opera.api.openapi.models.just_message import JustMessage  # noqa: E501
+from opera.api.util import xopera_util
+
+logger = get_logger(__name__)
+
+
+def post_validate(blueprint_token, version_tag=None):
+    """post_validate
+
+    Validates TOSCA service template # noqa: E501
+
+    :param blueprint_token: Token of TOSCA blueprint
+    :type blueprint_token: str
+    :param version_tag: Version_tag to of TOSCA blueprint
+    :type version_tag: str
+
+    :rtype: JustMessage
+    """
+    inputs = xopera_util.inputs_file()
+
+    if not CSAR_db.version_exists(blueprint_token, version_tag):
+        return JustMessage(
+            f"Did not find blueprint with token: {blueprint_token} and version_id: {version_tag or 'any'}"), 404
+
+    exception = InvocationWorkerProcess.validate(blueprint_token, version_tag, inputs)
+    if exception:
+        return ErrorMsg(exception[0], exception[1]), 500
+    return JustMessage("Validation OK"), 200

--- a/src/opera/api/gitCsarDB/main.py
+++ b/src/opera/api/gitCsarDB/main.py
@@ -103,7 +103,7 @@ class GitCsarDB:
                 raise FileNotFoundError(f"Tag '{version_tag}' not found")
         repo_path = dst or git_clone_path
         if repo_path != git_clone_path:
-            shutil.copytree(git_clone_path, repo_path)
+            shutil.copytree(git_clone_path, repo_path, dirs_exist_ok=True)
             # remove .git dir
             shutil.rmtree(Path(repo_path / Path(".git")))
             shutil.rmtree(git_clone_path)

--- a/src/opera/api/gitCsarDB/main.py
+++ b/src/opera/api/gitCsarDB/main.py
@@ -3,6 +3,7 @@ import time
 import uuid
 from pathlib import Path
 
+import tempfile
 import git
 
 from . import tag_util
@@ -16,7 +17,7 @@ class GitCsarDB:
     class UnsupportedConnectorType(GitCsarDBError):
         pass
 
-    def __init__(self, connector: Connector, workdir="/tmp/git_db", repo_prefix='gitDB_',
+    def __init__(self, connector: Connector, workdir=tempfile.mkdtemp(), repo_prefix='gitDB_',
                  commit_name="SODALITE-xOpera-REST-API", commit_mail="some-email@xlab.si",
                  guest_permissions="reporter", timeout=60):
         self.git_connector = connector

--- a/src/opera/api/service/csardb_service.py
+++ b/src/opera/api/service/csardb_service.py
@@ -38,6 +38,12 @@ class GitDB:
         """
         return self.connection.get_tags_list(csar_token=blueprint_token)
 
+    def get_last_tag(self, blueprint_token: uuid):
+        try:
+            return self.get_tags(blueprint_token)[-1]
+        except IndexError:
+            return None
+
     def add_revision(self, blueprint_token: uuid = None, CSAR: FileStorage = None,
                      blueprint_path: Path = None, revision_msg: str = None, minor_to_increment: str = None):
         """

--- a/src/opera/api/service/csardb_service.py
+++ b/src/opera/api/service/csardb_service.py
@@ -1,6 +1,7 @@
 import logging as log
 import shutil
 import uuid
+import tempfile
 from pathlib import Path
 
 from werkzeug.datastructures import FileStorage
@@ -54,12 +55,12 @@ class GitDB:
         will be incremented
         """
         token = uuid.uuid4() if not blueprint_token else blueprint_token
-        path = Path(f'/tmp/{uuid.uuid4()}') if not blueprint_path else blueprint_path
+        path = Path(tempfile.mkdtemp()) if not blueprint_path else blueprint_path
 
         if CSAR is not None:
-            workdir = Path(f'/tmp/{uuid.uuid4()}')
+            workdir = Path(tempfile.mkdtemp())
             CSAR_path = workdir / Path(CSAR.filename)
-            workdir.mkdir(parents=True)
+            workdir.mkdir(parents=True, exist_ok=True)
             CSAR.save(CSAR_path.open('wb'))
             try:
                 csar_to_blueprint(csar=CSAR_path, dst=path)

--- a/src/opera/api/service/sqldb_service.py
+++ b/src/opera/api/service/sqldb_service.py
@@ -130,22 +130,10 @@ class OfflineStorage(Database):
 
     def get_session_data(self, session_token):
         try:
-            return json.loads(self.file_read(str(self.dot_opera_data_path), session_token))
+            session_data = json.loads(self.file_read(str(self.dot_opera_data_path), session_token))
+            return {k: (v if v != 'None' else None) for k, v in session_data.items()}
         except FileNotFoundError:
             return None
-
-    # def get_last_session_data(self, blueprint_token):
-    #     my_list = []
-    #     for session_file in self.dot_opera_data_path.glob('*'):
-    #         if session_file.is_file():
-    #             session_data = json.loads(session_file.read_text())
-    #             if session_data['blueprint_token'] == blueprint_token:
-    #                 my_list.append((session_data['timestamp'], session_file.name))
-    #     try:
-    #         last_session_token = sorted(my_list, key=lambda x: x[0], reverse=True)[0][1]
-    #         return self.get_session_data(last_session_token)
-    #     except IndexError:
-    #         return None
 
     def update_deployment_log(self, blueprint_token: str, _log: str, session_token: str, timestamp: str):
         """

--- a/src/opera/api/tests/test_03_gitCsarDB.py
+++ b/src/opera/api/tests/test_03_gitCsarDB.py
@@ -1,4 +1,5 @@
 import uuid
+import tempfile
 from pathlib import Path
 
 import opera.api.gitCsarDB as gitCsarDB
@@ -6,14 +7,10 @@ from opera.api.gitCsarDB import GitCsarDB
 
 
 def test_connect_function():
-    db_mock = gitCsarDB.connect(type='mock', mock_workdir='/tmp/blah')
-    assert isinstance(db_mock, GitCsarDB)
-    assert isinstance(db_mock.git_connector, gitCsarDB.MockConnector)
-
-
-def test_default_params(db: GitCsarDB):
-    assert db.workdir == Path("/tmp/git_db")
-    assert db.repo_prefix == 'gitDB_'
+    with tempfile.TemporaryDirectory() as workdir:
+        db_mock = gitCsarDB.connect(type='mock', mock_workdir=workdir)
+        assert isinstance(db_mock, GitCsarDB)
+        assert isinstance(db_mock.git_connector, gitCsarDB.MockConnector)
 
 
 def test_token_to_repo_name(db: GitCsarDB):

--- a/src/opera/api/tests/test_14_validate.py
+++ b/src/opera/api/tests/test_14_validate.py
@@ -1,0 +1,42 @@
+import uuid
+
+from assertpy import assert_that
+
+
+class TestValidate:
+
+    def test_no_blueprint(self, client, mocker):
+        blueprint_token = str(uuid.uuid4())
+        version_tag = 'version_tag1'
+        mock_version_exists = mocker.MagicMock(name='version_exists', return_value=False)
+        mocker.patch('opera.api.service.csardb_service.GitDB.version_exists', new=mock_version_exists)
+
+        resp = client.post(f"/validate/{blueprint_token}?version_tag={version_tag}")
+        assert resp.status_code == 404
+        mock_version_exists.assert_called_with(blueprint_token, version_tag)
+
+    def test_exception(self, client, mocker):
+        blueprint_token = str(uuid.uuid4())
+        version_tag = 'version_tag3'
+        mocker.patch('opera.api.service.csardb_service.GitDB.version_exists', return_value=True)
+
+        mock_validate = mocker.MagicMock(name='validate', return_value=(Exception.__class__.__name__, "Exception "
+                                                                                                      "stacktrace"))
+        mocker.patch('opera.api.controllers.background_invocation.InvocationWorkerProcess.validate', new=mock_validate)
+        resp = client.post(f"/validate/{blueprint_token}?version_tag={version_tag}")
+
+        assert resp.status_code == 500
+        assert_that(resp.json).contains_only("description", "stacktrace")
+        mock_validate.assert_called_with(blueprint_token, version_tag, None)
+
+    def test_ok(self, client, mocker, inputs_1):
+        blueprint_token = str(uuid.uuid4())
+        version_tag = 'version_tag2'
+        mocker.patch('opera.api.service.csardb_service.GitDB.version_exists', return_value=True)
+        mock_validate = mocker.MagicMock(name='validate', return_value=None)
+        mocker.patch('opera.api.controllers.background_invocation.InvocationWorkerProcess.validate', new=mock_validate)
+        resp = client.post(f"/validate/{blueprint_token}?version_tag={version_tag}", data=inputs_1)
+
+        assert resp.status_code == 200
+        assert_that(resp.json).contains_only("message")
+        mock_validate.assert_called_with(blueprint_token, version_tag, {'marker': 'blah'})

--- a/src/opera/api/tests/test_15_outputs.py
+++ b/src/opera/api/tests/test_15_outputs.py
@@ -1,0 +1,48 @@
+import uuid
+
+from assertpy import assert_that
+
+
+class TestOutputs:
+
+    def test_no_blueprint(self, client, mocker):
+        session_token = str(uuid.uuid4())
+        mock_session_data = mocker.MagicMock(name='version_exists', return_value=False)
+        mocker.patch('opera.api.service.sqldb_service.OfflineStorage.get_session_data', new=mock_session_data)
+
+        resp = client.get(f"/outputs/{session_token}")
+        assert resp.status_code == 404
+        mock_session_data.assert_called_with(session_token)
+
+    def test_exception(self, client, mocker):
+        session_token = str(uuid.uuid4())
+        mocker.patch('opera.api.service.sqldb_service.OfflineStorage.get_session_data', return_value=True)
+
+        mock_outputs = mocker.MagicMock(name='outputs', return_value=(None, (Exception.__class__.__name__, "Exception "
+                                                                                                           "stacktrace")))
+        mocker.patch('opera.api.controllers.background_invocation.InvocationWorkerProcess.outputs', new=mock_outputs)
+        resp = client.get(f"/outputs/{session_token}")
+
+        assert resp.status_code == 500
+        assert_that(resp.json).contains_only("description", "stacktrace")
+        mock_outputs.assert_called_with(session_token)
+
+    def test_ok(self, client, mocker):
+        session_token = str(uuid.uuid4())
+        mocker.patch('opera.api.service.sqldb_service.OfflineStorage.get_session_data', return_value=True)
+        mock_outputs = mocker.MagicMock(name='outputs', return_value=({
+                                                                          "output1": {
+                                                                              "description": "first output",
+                                                                              "value": "foo"
+                                                                          },
+                                                                          "output2": {
+                                                                              "description": "second output",
+                                                                              "value": "bar"
+                                                                          }
+                                                                      }, None))
+        mocker.patch('opera.api.controllers.background_invocation.InvocationWorkerProcess.outputs', new=mock_outputs)
+        resp = client.get(f"/outputs/{session_token}")
+
+        assert resp.status_code == 200
+        assert_that(resp.json).contains_only("output1", "output2")
+        mock_outputs.assert_called_with(session_token)

--- a/src/opera/api/tests/test_15_outputs.py
+++ b/src/opera/api/tests/test_15_outputs.py
@@ -4,19 +4,35 @@ from assertpy import assert_that
 
 
 class TestOutputs:
+    blueprint_token = '4a7b9983-dc27-4e43-b7b3-8b696a550fac'
+    version_tag = 'version_tag'
+    session_data = {'blueprint_token': blueprint_token, 'version_tag': version_tag}
+
+    def test_no_session_data(self, client, mocker):
+        mock_get_session_data = mocker.MagicMock(name='session_data', return_value=None)
+        mocker.patch('opera.api.service.sqldb_service.OfflineStorage.get_session_data', new=mock_get_session_data)
+
+        session_token = uuid.uuid4()
+        resp = client.get(f"/outputs/{session_token}")
+        assert resp.status_code == 404
+        mock_get_session_data.assert_called_with(str(session_token))
 
     def test_no_blueprint(self, client, mocker):
         session_token = str(uuid.uuid4())
-        mock_session_data = mocker.MagicMock(name='version_exists', return_value=False)
-        mocker.patch('opera.api.service.sqldb_service.OfflineStorage.get_session_data', new=mock_session_data)
+        mock_version_exists = mocker.MagicMock(name='version_exists', return_value=False)
+        mocker.patch('opera.api.service.sqldb_service.OfflineStorage.get_session_data',
+                     return_value=TestOutputs.session_data)
+        mocker.patch('opera.api.service.csardb_service.GitDB.version_exists', new=mock_version_exists)
 
         resp = client.get(f"/outputs/{session_token}")
         assert resp.status_code == 404
-        mock_session_data.assert_called_with(session_token)
+        mock_version_exists.assert_called_with(TestOutputs.blueprint_token, TestOutputs.version_tag)
 
     def test_exception(self, client, mocker):
         session_token = str(uuid.uuid4())
-        mocker.patch('opera.api.service.sqldb_service.OfflineStorage.get_session_data', return_value=True)
+        mocker.patch('opera.api.service.csardb_service.GitDB.version_exists', return_value=True)
+        mocker.patch('opera.api.service.sqldb_service.OfflineStorage.get_session_data',
+                     return_value=TestOutputs.session_data)
 
         mock_outputs = mocker.MagicMock(name='outputs', return_value=(None, (Exception.__class__.__name__, "Exception "
                                                                                                            "stacktrace")))
@@ -29,7 +45,9 @@ class TestOutputs:
 
     def test_ok(self, client, mocker):
         session_token = str(uuid.uuid4())
-        mocker.patch('opera.api.service.sqldb_service.OfflineStorage.get_session_data', return_value=True)
+        mocker.patch('opera.api.service.csardb_service.GitDB.version_exists', return_value=True)
+        mocker.patch('opera.api.service.sqldb_service.OfflineStorage.get_session_data',
+                     return_value=TestOutputs.session_data)
         mock_outputs = mocker.MagicMock(name='outputs', return_value=({
                                                                           "output1": {
                                                                               "description": "first output",

--- a/src/opera/api/util/xopera_util.py
+++ b/src/opera/api/util/xopera_util.py
@@ -89,3 +89,10 @@ def inputs_file():
         return yaml.safe_load(file.read().decode('utf-8'))
     except KeyError:
         return None
+
+
+def mask_workdir(location: Path, stacktrace: str, placeholder="$BLUEPRINT_DIR"):
+    """
+    replaces real workdir with placehodler
+    """
+    return stacktrace.replace(str(location), placeholder)


### PR DESCRIPTION
Adds two new opera commands: outputs and validate.
Other minor improvements:
- Review security hotspots
- Connect to DB once and then pass python object to other classes

Closes #67, closes #68 