### PR TITLE
Check if blueprint is still in use before deleting it

### DIFF
--- a/src/opera/api/controllers/blueprint_controller.py
+++ b/src/opera/api/controllers/blueprint_controller.py
@@ -42,8 +42,8 @@ def delete_blueprint(blueprint_id, force=None):
     :rtype: Blueprint
     """
     if not force:
-        # TODO check in DB if all deployments with blueprint have been deployed
-        if False:
+        # TODO test
+        if SQL_database.blueprint_used_in_deployment(blueprint_id):
             return "Cannot delete blueprint, deployment with this blueprint exists", 403
 
     repo_url, _ = CSAR_db.get_repo_url(blueprint_id)
@@ -84,8 +84,8 @@ def delete_blueprint_version(blueprint_id, version_id, force=None):
     :rtype: Blueprint
     """
     if not force:
-        # TODO check in DB if all deployments with blueprint have been deployed
-        if False:
+        # TODO test
+        if SQL_database.blueprint_used_in_deployment(blueprint_id, version_id):
             return "Cannot delete blueprint, deployment with this blueprint exists", 403
 
     repo_url, _ = CSAR_db.get_repo_url(blueprint_id)

--- a/src/opera/api/controllers/blueprint_controller.py
+++ b/src/opera/api/controllers/blueprint_controller.py
@@ -42,7 +42,6 @@ def delete_blueprint(blueprint_id, force=None):
     :rtype: Blueprint
     """
     if not force:
-        # TODO test
         if SQL_database.blueprint_used_in_deployment(blueprint_id):
             return "Cannot delete blueprint, deployment with this blueprint exists", 403
 
@@ -84,7 +83,6 @@ def delete_blueprint_version(blueprint_id, version_id, force=None):
     :rtype: Blueprint
     """
     if not force:
-        # TODO test
         if SQL_database.blueprint_used_in_deployment(blueprint_id, version_id):
             return "Cannot delete blueprint, deployment with this blueprint exists", 403
 

--- a/src/opera/api/service/sqldb_service.py
+++ b/src/opera/api/service/sqldb_service.py
@@ -433,7 +433,6 @@ class PostgreSQL(Database):
             return False
 
         if version_id:
-            # TODO check if last version
             dbcur = self.connection.cursor()
             for deployment_id in deployment_ids:
                 query = "select version_id from {} where deployment_id = '{}' order by timestamp desc limit 1"\

--- a/src/opera/api/util/file_util.py
+++ b/src/opera/api/util/file_util.py
@@ -28,5 +28,5 @@ class UUIDEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, UUID):
             # if the obj is uuid, we simply return the value of uuid
-            return obj.hex
+            return str(obj)
         return json.JSONEncoder.default(self, obj)


### PR DESCRIPTION
Implements function that check if blueprint (version) was used in any deployment. Functionality is added to these two endpoints:

## [DELETE] /blueprint/{blueprint_id}
REST API checks if a blueprint was used in any deployment. Since all invocations from one deployment should be deployed from the same blueprint (but possibly different versions), it does not explicitly check the last invocation, simply checks if a blueprint is part of an invocation. It can be overridden with `force=true` flag.

## [DELETE] /blueprint/{blueprint_id}/version/{version_id}
REST API checks if a specific blueprint version is used in the last invocation of any deployment. It can be overridden with `force=true` flag.

Closes #74.