### PR TITLE
Update HTTP status codes

### DIFF
--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -74,7 +74,7 @@ paths:
                   format: binary
         required: true
       responses:
-        200:
+        201:
           description: Successfully saved blueprint to database
           content:
             application/json:
@@ -129,7 +129,7 @@ paths:
                   format: binary
         required: true
       responses:
-        200:
+        201:
           description: Successfully saved blueprint to database
           content:
             application/json:
@@ -142,7 +142,7 @@ paths:
               schema:
                 type: string
         404:
-          description: Blueprint token not found
+          description: Blueprint not found
           content:
             application/json:
               schema:
@@ -274,7 +274,7 @@ paths:
           format: uuid
       responses:
         200:
-          description: user list returned
+          description: User list returned
           content:
             application/json:
               schema:
@@ -289,13 +289,13 @@ paths:
               schema:
                 type: string
         404:
-          description: blueprint not found
+          description: Blueprint not found
           content:
             application/json:
               schema:
                 type: string
         500:
-          description: DB error when getting user list
+          description: DB or REST API error
           content:
             application/json:
               schema:
@@ -325,7 +325,7 @@ paths:
         schema:
           type: string
       responses:
-        201:
+        200:
           description: User added or invite send
           content:
             application/json:
@@ -344,7 +344,7 @@ paths:
               schema:
                 type: string
         500:
-          description: DB error when adding user
+          description: DB or REST API error
           content:
             application/json:
               schema:
@@ -372,8 +372,8 @@ paths:
         schema:
           type: string
       responses:
-        201:
-          description: User de;eted
+        200:
+          description: User deleted
           content:
             application/json:
               schema:
@@ -391,7 +391,7 @@ paths:
               schema:
                 type: string
         500:
-          description: DB error when deleting user
+          description: DB or REST API error
           content:
             application/json:
               schema:
@@ -428,7 +428,7 @@ paths:
                   format: binary
       responses:
         200:
-          description: OK
+          description: Blueprint validated
           content:
             application/json:
               schema:
@@ -441,12 +441,6 @@ paths:
                 type: string
         404:
           description: Did not find blueprint
-          content:
-            application/json:
-              schema:
-                type: string
-        500:
-          description: Fail
           content:
             application/json:
               schema:
@@ -490,7 +484,7 @@ paths:
                   format: binary
       responses:
         200:
-          description: OK
+          description: Blueprint validated
           content:
             application/json:
               schema:
@@ -503,12 +497,6 @@ paths:
                 type: string
         404:
           description: Did not find blueprint
-          content:
-            application/json:
-              schema:
-                type: string
-        500:
-          description: Fail
           content:
             application/json:
               schema:
@@ -543,7 +531,7 @@ paths:
         required: true
       responses:
         200:
-          description: OK
+          description: Blueprint validated
           content:
             application/json:
               schema:
@@ -556,12 +544,6 @@ paths:
                 type: string
         404:
           description: Did not find blueprint
-          content:
-            application/json:
-              schema:
-                type: string
-        500:
-          description: Fail
           content:
             application/json:
               schema:
@@ -762,12 +744,6 @@ paths:
             application/json:
               schema:
                 type: string
-        500:
-          description: Job failed
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Invocation'
 
   /deployment/{deployment_id}/history:
     get:
@@ -917,7 +893,6 @@ paths:
             application/json:
               schema:
                 type: object
-                #$ref: '#/components/schemas/Invocation'
         401:
           description: Unauthorized request for this blueprint
           content:

--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -92,6 +92,12 @@ paths:
             application/json:
               schema:
                 type: string
+        500:
+          description: DB or REST API exception
+          content:
+            application/json:
+              schema:
+                type: string
 
   /blueprint/{blueprint_id}:
     post:
@@ -281,7 +287,6 @@ paths:
                 type: array
                 items:
                   type: string
-
         401:
           description: Unauthorized request for this blueprint
           content:
@@ -720,14 +725,8 @@ paths:
           type: string
           format: uuid
       responses:
-        201:
-          description: Job done
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Invocation'
-        202:
-          description: Job accepted, still running
+        200:
+          description: Job found
           content:
             application/json:
               schema:
@@ -771,7 +770,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Invocation'
-        400:
+        404:
           description: Log file not found
           content:
             application/json:
@@ -833,6 +832,12 @@ paths:
                 $ref: '#/components/schemas/Invocation'
         401:
           description: Unauthorized request for this blueprint
+          content:
+            application/json:
+              schema:
+                type: string
+        403:
+          description: Not allowed, previous operation on deployment still running
           content:
             application/json:
               schema:
@@ -967,6 +972,12 @@ paths:
             application/json:
               schema:
                 type: string
+        403:
+          description: Not allowed, previous operation on deployment still running
+          content:
+            application/json:
+              schema:
+                type: string
         404:
           description: Did not find DI1 or DB2
           content:
@@ -1021,7 +1032,7 @@ paths:
               schema:
                 type: string
         403:
-          description: Undeploy not allowed
+          description: Not allowed, previous operation on deployment still running
           content:
             application/json:
               schema:

--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -437,7 +437,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/BlueprintValidation'
         401:
           description: Unauthorized request for this blueprint
           content:
@@ -493,7 +493,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/BlueprintValidation'
         401:
           description: Unauthorized request for this blueprint
           content:
@@ -540,7 +540,7 @@ paths:
           content:
             application/json:
               schema:
-                type: string
+                $ref: '#/components/schemas/BlueprintValidation'
         401:
           description: Unauthorized request for this blueprint
           content:
@@ -1046,6 +1046,17 @@ paths:
 
 components:
   schemas:
+    BlueprintValidation:
+      required:
+        - blueprint_valid
+      type: object
+      properties:
+        blueprint_valid:
+          type: boolean
+          description: Blueprint is a valid TOSCA Cloud Service Archive
+        error:
+          type: string
+          description: Error description
     KeyPair:
       required:
       - key_pair_name
@@ -1141,7 +1152,6 @@ components:
       type: object
       required:
         - blueprint_id
-      #  - invocation_id
         - deployment_id
         - state
         - operation

--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -331,7 +331,7 @@ paths:
           type: string
       responses:
         200:
-          description: User added or invite send
+          description: User added or invite sent
           content:
             application/json:
               schema:

--- a/src/opera/api/controllers/blueprint_controller.py
+++ b/src/opera/api/controllers/blueprint_controller.py
@@ -25,7 +25,7 @@ def delete_git_user(blueprint_id, user_id):
     """
     success, error_msg = CSAR_db.delete_blueprint_user(blueprint_id=blueprint_id, username=user_id)
     if success:
-        return f"User {user_id} deleted", 201
+        return f"User {user_id} deleted", 200
 
     return f"Could not delete user {user_id} from repository with blueprint_id '{blueprint_id}': {error_msg}", 500
 
@@ -162,7 +162,7 @@ def post_git_user(blueprint_id, user_id):
             'gitlab': f"User {user_id} added",
             'mock': f"User {user_id} added"
         }
-        return message[Settings.git_config['type']], 201
+        return message[Settings.git_config['type']], 200
 
     return f"Could not add user {user_id} to repository with blueprint_id '{blueprint_id}': {error_msg}", 500
 
@@ -193,7 +193,7 @@ def post_blueprint(blueprint_id, revision_msg=None):
                                            repo_url=result['url'],
                                            commit_sha=result['commit_sha'])
 
-    return Blueprint.from_dict(result), 200
+    return Blueprint.from_dict(result), 201
 
 
 def post_new_blueprint(revision_msg=None, project_domain=None):
@@ -228,7 +228,7 @@ def post_new_blueprint(revision_msg=None, project_domain=None):
                                            repo_url=result['url'],
                                            commit_sha=result['commit_sha'])
 
-    return Blueprint.from_dict(result), 200
+    return Blueprint.from_dict(result), 201
 
 
 @security_controller.check_role_auth_blueprint
@@ -245,9 +245,7 @@ def validate_existing(blueprint_id):
     inputs = xopera_util.inputs_file()
 
     exception = InvocationWorkerProcess.validate(blueprint_id, None, inputs)
-    if exception:
-        return exception, 500
-    return "Validation OK", 200
+    return exception or "Validation OK", 200
 
 
 @security_controller.check_role_auth_blueprint
@@ -266,9 +264,7 @@ def validate_existing_version(blueprint_id, version_id):
     inputs = xopera_util.inputs_file()
 
     exception = InvocationWorkerProcess.validate(blueprint_id, version_id, inputs)
-    if exception:
-        return exception, 500
-    return "Validation OK", 200
+    return exception or "Validation OK", 200
 
 
 def validate_new():
@@ -282,7 +278,5 @@ def validate_new():
     csar_file = connexion.request.files['CSAR']
 
     exception = InvocationWorkerProcess.validate_new(csar_file, inputs)
-    if exception:
-        return exception, 500
-    return "Validation OK", 200
+    return exception or "Validation OK", 200
 

--- a/src/opera/api/controllers/blueprint_controller.py
+++ b/src/opera/api/controllers/blueprint_controller.py
@@ -6,6 +6,7 @@ from opera.api.controllers.background_invocation import InvocationWorkerProcess
 from opera.api.log import get_logger
 from opera.api.openapi.models.blueprint import Blueprint
 from opera.api.openapi.models.git_log import GitLog
+from opera.api.openapi.models.blueprint_validation import BlueprintValidation
 from opera.api.settings import Settings
 from opera.api.util import timestamp_util, xopera_util
 
@@ -245,7 +246,8 @@ def validate_existing(blueprint_id):
     inputs = xopera_util.inputs_file()
 
     exception = InvocationWorkerProcess.validate(blueprint_id, None, inputs)
-    return exception or "Validation OK", 200
+    blueprint_valid = exception is None
+    return BlueprintValidation(blueprint_valid, exception), 200
 
 
 @security_controller.check_role_auth_blueprint
@@ -264,7 +266,8 @@ def validate_existing_version(blueprint_id, version_id):
     inputs = xopera_util.inputs_file()
 
     exception = InvocationWorkerProcess.validate(blueprint_id, version_id, inputs)
-    return exception or "Validation OK", 200
+    blueprint_valid = exception is None
+    return BlueprintValidation(blueprint_valid, exception), 200
 
 
 def validate_new():
@@ -278,5 +281,6 @@ def validate_new():
     csar_file = connexion.request.files['CSAR']
 
     exception = InvocationWorkerProcess.validate_new(csar_file, inputs)
-    return exception or "Validation OK", 200
+    blueprint_valid = exception is None
+    return BlueprintValidation(blueprint_valid, exception), 200
 

--- a/src/opera/api/controllers/deployment_controller.py
+++ b/src/opera/api/controllers/deployment_controller.py
@@ -53,14 +53,7 @@ def get_status(deployment_id):
     :rtype: Invocation
     """
     inv = invocation_service.load_invocation(deployment_id)
-    code = {
-        InvocationState.PENDING: 202,
-        InvocationState.IN_PROGRESS: 202,
-        InvocationState.SUCCESS: 201,
-        InvocationState.FAILED: 500
-    }
-
-    return inv, code[inv.state]
+    return inv, 200
 
 
 @security_controller.check_role_auth_deployment

--- a/src/opera/api/controllers/deployment_controller.py
+++ b/src/opera/api/controllers/deployment_controller.py
@@ -39,7 +39,7 @@ def get_deploy_log(deployment_id):
     """
     history = SQL_database.get_deployment_history(deployment_id)
     if not history:
-        return "History not found", 400
+        return "History not found", 404
     return history, 200
 
 

--- a/src/opera/api/tests/test_09_blueprint.py
+++ b/src/opera/api/tests/test_09_blueprint.py
@@ -37,7 +37,7 @@ class TestPostNew:
 
     def test_success(self, client, csar_1):
         resp = client.post("/blueprint", data=csar_1)
-        assert_that(resp.status_code).is_equal_to(200)
+        assert_that(resp.status_code).is_equal_to(201)
         assert_that(resp.json).is_not_none().contains_only('blueprint_id', 'url',
                                                            'version_id', 'users', 'commit_sha', 'timestamp')
         uuid.UUID(resp.get_json()['blueprint_id'])
@@ -68,7 +68,7 @@ class TestPostMultipleVersions:
     def test_emtpy_request(self, client, csar_empty, csar_1):
         # prepare blueprint
         resp = client.post("/blueprint", data=csar_1)
-        assert_that(resp.status_code).is_equal_to(200)
+        assert_that(resp.status_code).is_equal_to(201)
         token = resp.json['blueprint_id']
 
         resp = client.post("/blueprint/{}".format(token), data=csar_empty, content_type='multipart/form-data')
@@ -81,7 +81,7 @@ class TestPostMultipleVersions:
         blueprint_id = resp1.json['blueprint_id']
         # test new version
         resp2 = client.post(f"/blueprint/{blueprint_id}", data=csar_2)
-        assert_that(resp2.status_code).is_equal_to(200)
+        assert_that(resp2.status_code).is_equal_to(201)
         assert_that(resp2.json).is_not_none().contains_only('blueprint_id', 'url', 'version_id',
                                                             'users', 'commit_sha', 'timestamp')
         assert_that(resp2.json['version_id']).is_equal_to('v2.0')
@@ -242,7 +242,7 @@ class TestUser:
         resp = client.post(f"/blueprint/{blueprint_token}/user/{username}")
         # since this is MockConnector, message should be 'user foo added'
         assert_that(resp.json).is_equal_to('User foo added')
-        assert_that(resp.status_code).is_equal_to(201)
+        assert_that(resp.status_code).is_equal_to(200)
 
         resp = client.get(f"/blueprint/{blueprint_token}/user")
         assert_that(resp.json).is_not_empty().contains_only('foo')
@@ -268,7 +268,7 @@ class TestUser:
 
         resp = client.delete(f"/blueprint/{blueprint_token}/user/{username}")
         assert_that(resp.json).is_equal_to('User foo deleted')
-        assert_that(resp.status_code).is_equal_to(201)
+        assert_that(resp.status_code).is_equal_to(200)
         resp = client.get(f"/blueprint/{blueprint_token}/user")
         assert_that(resp.json).is_empty()
 
@@ -294,7 +294,7 @@ class TestValidateExisting:
         mocker.patch('opera.api.controllers.background_invocation.InvocationWorkerProcess.validate', new=mock_validate)
         resp = client.put(f"/blueprint/{blueprint_id}/validate")
 
-        assert resp.status_code == 500
+        assert resp.status_code == 200
         assert_that(resp.json).contains("Exception stacktrace")
         mock_validate.assert_called_with(str(blueprint_id), None, None)
 
@@ -332,7 +332,7 @@ class TestValidateExistingVersion:
         mocker.patch('opera.api.controllers.background_invocation.InvocationWorkerProcess.validate', new=mock_validate)
         resp = client.put(f"/blueprint/{blueprint_id}/version/{version_id}/validate")
 
-        assert resp.status_code == 500
+        assert resp.status_code == 200
         assert_that(resp.json).contains("Exception stacktrace")
         mock_validate.assert_called_with(str(blueprint_id), version_id, None)
 
@@ -356,7 +356,7 @@ class TestValidateNew:
                      return_value="{}: {}".format(Exception.__class__.__name__, "Exception stacktrace"))
         resp = client.put(f"/blueprint/validate", data=csar_1)
 
-        assert resp.status_code == 500
+        assert resp.status_code == 200
         assert_that(resp.json).contains("Exception stacktrace")
 
     def test_ok(self, client, mocker, csar_1):

--- a/src/opera/api/tests/test_09_blueprint.py
+++ b/src/opera/api/tests/test_09_blueprint.py
@@ -295,7 +295,9 @@ class TestValidateExisting:
         resp = client.put(f"/blueprint/{blueprint_id}/validate")
 
         assert resp.status_code == 200
-        assert_that(resp.json).contains("Exception stacktrace")
+        assert_that(resp.json).contains_only("blueprint_valid", "error")
+        assert_that(resp.json['blueprint_valid']).is_false()
+        assert_that(resp.json['error']).contains("Exception stacktrace")
         mock_validate.assert_called_with(str(blueprint_id), None, None)
 
     def test_ok(self, client, mocker, inputs_1):
@@ -306,7 +308,8 @@ class TestValidateExisting:
         resp = client.put(f"/blueprint/{blueprint_token}/validate", data=inputs_1)
 
         assert resp.status_code == 200
-        assert_that(resp.json).contains("Validation OK")
+        assert_that(resp.json).contains_only("blueprint_valid")
+        assert_that(resp.json['blueprint_valid']).is_true()
         mock_validate.assert_called_with(str(blueprint_token), None, {'marker': 'blah'})
 
 
@@ -333,7 +336,9 @@ class TestValidateExistingVersion:
         resp = client.put(f"/blueprint/{blueprint_id}/version/{version_id}/validate")
 
         assert resp.status_code == 200
-        assert_that(resp.json).contains("Exception stacktrace")
+        assert_that(resp.json).contains_only("blueprint_valid", "error")
+        assert_that(resp.json['blueprint_valid']).is_false()
+        assert_that(resp.json['error']).contains("Exception stacktrace")
         mock_validate.assert_called_with(str(blueprint_id), version_id, None)
 
     def test_ok(self, client, mocker, inputs_1):
@@ -345,7 +350,8 @@ class TestValidateExistingVersion:
         resp = client.put(f"/blueprint/{blueprint_token}/version/{version_id}/validate", data=inputs_1)
 
         assert resp.status_code == 200
-        assert_that(resp.json).contains("Validation OK")
+        assert_that(resp.json).contains_only("blueprint_valid")
+        assert_that(resp.json['blueprint_valid']).is_true()
         mock_validate.assert_called_with(str(blueprint_token), version_id, {'marker': 'blah'})
 
 
@@ -357,14 +363,17 @@ class TestValidateNew:
         resp = client.put(f"/blueprint/validate", data=csar_1)
 
         assert resp.status_code == 200
-        assert_that(resp.json).contains("Exception stacktrace")
+        assert_that(resp.json).contains_only("blueprint_valid", "error")
+        assert_that(resp.json['blueprint_valid']).is_false()
+        assert_that(resp.json['error']).contains("Exception stacktrace")
 
     def test_ok(self, client, mocker, csar_1):
         mocker.patch('opera.api.controllers.background_invocation.InvocationWorkerProcess.validate', return_value=None)
         resp = client.put(f"/blueprint/validate", data=csar_1)
 
         assert resp.status_code == 200
-        assert_that(resp.json).contains("Validation OK")
+        assert_that(resp.json).contains_only("blueprint_valid")
+        assert_that(resp.json['blueprint_valid']).is_true()
 
 
 class TestGitHistory:

--- a/src/opera/api/tests/test_10_deployment.py
+++ b/src/opera/api/tests/test_10_deployment.py
@@ -120,7 +120,7 @@ class TestHistory:
         mocker.patch('opera.api.service.sqldb_service.OfflineStorage.get_deployment_history', return_value=[])
         deployment_id = uuid.uuid4()
         resp = client.get(f"/deployment/{deployment_id}/history")
-        assert resp.status_code == 400
+        assert resp.status_code == 404
         assert_that(resp.json).contains("History not found")
 
     def test_success(self, client, mocker, generic_invocation: Invocation, patch_auth_wrapper):

--- a/src/opera/api/tests/test_10_deployment.py
+++ b/src/opera/api/tests/test_10_deployment.py
@@ -75,7 +75,7 @@ class TestStatus:
 
         resp = client.get(f"/deployment/{inv.deployment_id}/status")
         assert resp.json['state'] == inv.state
-        assert resp.status_code == 202
+        assert resp.status_code == 200
 
     def test_in_progress(self, client, generic_invocation: Invocation, patch_auth_wrapper):
         inv = generic_invocation
@@ -89,7 +89,7 @@ class TestStatus:
 
         resp = client.get(f"/deployment/{inv.deployment_id}/status")
         assert resp.json['state'] == inv.state
-        assert resp.status_code == 202
+        assert resp.status_code == 200
 
     def test_success(self, client, generic_invocation: Invocation, patch_auth_wrapper):
         inv = generic_invocation
@@ -100,7 +100,7 @@ class TestStatus:
 
         resp = client.get(f"/deployment/{inv.deployment_id}/status")
         assert resp.json['state'] == inv.state
-        assert resp.status_code == 201
+        assert resp.status_code == 200
 
     def test_failed(self, client, generic_invocation: Invocation, patch_auth_wrapper):
         inv = generic_invocation
@@ -111,7 +111,7 @@ class TestStatus:
 
         resp = client.get(f"/deployment/{inv.deployment_id}/status")
         assert resp.json['state'] == inv.state
-        assert resp.status_code == 500
+        assert resp.status_code == 200
 
 
 class TestHistory:


### PR DESCRIPTION
In the past, several endpoints returned wrong HTTP codes.

xOpera REST API now uses the following HTTP codes :

### 2xx - success
201: New resource was created
202: Request was accepted, still running (or pending)
200: Success, no new resource was created

### 4xx - client errors
401 - Unauthorized
403 - Not allowed (job (since previous still running), delete_blueprint (deployment exist)) 
404 - Not found (blueprint, log, deployment, user,...)

### 5xx - Code, used exclusively for server errors. 

Closes #81.