### PR TITLE
Security controller checks if blueprint_version exists in PostgreSQL

### DIFF
--- a/src/opera/api/controllers/security_controller.py
+++ b/src/opera/api/controllers/security_controller.py
@@ -111,7 +111,7 @@ def check_role_auth_blueprint(func):
             return f"Authorization configuration error", 401
 
         version_id = kwargs.get("version_id")
-        if not CSAR_db.version_exists(blueprint_id, version_id):
+        if not SQL_database.version_exists(blueprint_id, version_id) and not CSAR_db.version_exists(blueprint_id, version_id):
             return f"Did not find blueprint with id: {blueprint_id} and version_id: {version_id or 'any'}", 404
 
         project_domain = SQL_database.get_project_domain(blueprint_id)
@@ -150,7 +150,7 @@ def check_role_auth_deployment(func):
         if not inv:
             return f"Deployment with id: {deployment_id} does not exist", 404
 
-        if not CSAR_db.version_exists(inv.blueprint_id, inv.version_id):
+        if not SQL_database.version_exists(inv.blueprint_id, inv.version_id) and not CSAR_db.version_exists(inv.blueprint_id, inv.version_id):
             return f"Did not find blueprint with id: {inv.blueprint_id} and version_id: {inv.version_id or 'any'}", 404
 
         project_domain = SQL_database.get_project_domain(inv.blueprint_id)
@@ -161,32 +161,3 @@ def check_role_auth_deployment(func):
 
     return wrapper_check_role_auth
 
-# def check_role_auth_deployment_or_blueprint(func):
-#     @functools.wraps(func)
-#     def wrapper_check_role_auth(*args, **kwargs):
-#         deployment_id = kwargs.get("deployment_id")
-#         blueprint_id = kwargs.get("blueprint_id")
-#         if not deployment_id and not blueprint_id:
-#             return f"No tokens provided", 404
-#
-#         elif deployment_id:
-#             inv = SQL_database.get_deployment_status(deployment_id)
-#             if not inv:
-#                 return f"Deployment with id: {deployment_id} does not exist", 404
-#
-#             blueprint_id = inv.blueprint_id
-#             version_id = kwargs.get("version_id", inv.version_id)
-#             if not CSAR_db.version_exists(inv.blueprint_id, inv.version_id):
-#                 return f"Did not find blueprint with id: {inv.blueprint_id} and version_id: {inv.version_id or 'any'}", 404
-#         elif blueprint_id:
-#             version_id = kwargs.get("version_id")
-#             if not CSAR_db.version_exists(blueprint_id, version_id):
-#                 return f"Did not find blueprint with id: {blueprint_id} and version_id: {version_id or 'any'}", 404
-#
-#         project_domain = SQL_database.get_project_domain(blueprint_id)
-#         if project_domain and not check_roles(project_domain):
-#             return f"Unauthorized request for project: {project_domain}", 401
-#
-#         return func(*args, **kwargs)
-#
-#     return wrapper_check_role_auth

--- a/src/opera/api/gitCsarDB/connectors.py
+++ b/src/opera/api/gitCsarDB/connectors.py
@@ -6,6 +6,10 @@ import git
 import gitlab
 from github import Github, GithubException
 from gitlab import Gitlab
+from opera.api.log import get_logger
+
+
+logger = get_logger(__name__)
 
 
 class Connector:
@@ -305,7 +309,7 @@ class GitlabConnector(Connector):
             project = gl.projects.create({'name': repo_name, 'visibility': "private"})
         except gitlab.exceptions.GitlabCreateError as e:
             raise self.RepoExistsError(
-                f"Could not create repo {repo_name} at {self.url}, repo already exists: {str(e)}")
+                f"Could not create repo {repo_name} at {self.url}: {str(e)}")
 
     def __project_id(self, project_name):
         gl = Gitlab(url=self.url, private_token=self.auth_token)

--- a/src/opera/api/service/csardb_service.py
+++ b/src/opera/api/service/csardb_service.py
@@ -1,4 +1,3 @@
-import logging as log
 import shutil
 import tempfile
 import uuid
@@ -10,6 +9,10 @@ from opera.api import gitCsarDB
 from opera.api.blueprint_converters import csar_to_blueprint
 from opera.api.blueprint_converters.blueprint2CSAR import validate_csar
 from opera.api.util.timestamp_util import datetime_now_to_string
+from opera.api.log import get_logger
+
+
+logger = get_logger(__name__)
 
 
 class GitDB:
@@ -65,14 +68,14 @@ class GitDB:
             try:
                 csar_to_blueprint(csar=CSAR_path, dst=path)
             except shutil.ReadError as e:
-                log.error(str(e))
+                logger.error(str(e))
                 shutil.rmtree(str(workdir))
                 return None, str(e)
             shutil.rmtree(str(workdir))
             try:
                 validate_csar(path, raise_exceptions=True)
             except Exception as e:
-                log.error(str(e))
+                logger.error(str(e))
                 shutil.rmtree(str(path))
                 return None, str(e)
 
@@ -152,20 +155,20 @@ class GitDB:
         if version_id is not None:
             try:
                 if self.connection.delete_tag(csar_token=blueprint_id, version_tag=version_id):
-                    log.debug(f'deleted tag {version_id}')
+                    logger.debug(f'deleted tag {version_id}')
                     return 1, 200
-                log.debug(f'tag {version_id} does not exist')
+                logger.debug(f'tag {version_id} does not exist')
                 return 0, 404  # tag does not exist
             except FileNotFoundError as e:
-                log.debug(str(e))
+                logger.debug(str(e))
                 return 0, 404  # blueprint does not exist
 
         try:
 
             return self.connection.delete_repo(csar_token=blueprint_id), 200
         except FileNotFoundError as e:
-            log.debug(str(e))
+            logger.debug(str(e))
             return 0, 404
         except Exception as e:
-            log.error(str(e))
+            logger.error(str(e))
             return 0, 500

--- a/src/opera/api/service/sqldb_service.py
+++ b/src/opera/api/service/sqldb_service.py
@@ -1,5 +1,4 @@
 import json
-import logging as log
 import os
 import uuid
 
@@ -18,11 +17,11 @@ def connect(sql_config):
         return OfflineStorage()
     try:
         database = PostgreSQL(sql_config)
-        log.info('SQL_database: PostgreSQL')
+        logger.info('SQL_database: PostgreSQL')
     except psycopg2.Error as e:
-        log.error(f"Error while connecting to PostgreSQL: {str(e)}")
+        logger.error(f"Error while connecting to PostgreSQL: {str(e)}")
         database = OfflineStorage()
-        log.info("SQL_database: OfflineStorage")
+        logger.info("SQL_database: OfflineStorage")
 
     return database
 
@@ -305,9 +304,9 @@ class OfflineStorage(Database):
             (location / str(timestamp)).write_text(json.dumps(git_transaction_data, indent=2))
         except Exception as e:
 
-            log.error(f'Failed to update git log in OfflineStorage database: {str(e)}')
+            logger.error(f'Failed to update git log in OfflineStorage database: {str(e)}')
             return False
-        log.info('Updated git log in OfflineStorage database')
+        logger.info('Updated git log in OfflineStorage database')
         return True
 
     def get_git_transaction_data(self, blueprint_id, version_id=None, fetch_all=False):
@@ -402,7 +401,7 @@ class PostgreSQL(Database):
                         );""".format(Settings.project_domain_table))
 
     def disconnect(self):
-        log.info('disconnecting PostgreSQL database')
+        logger.info('disconnecting PostgreSQL database')
         self.connection.close()
 
     def execute(self, command, replacements=None):
@@ -413,7 +412,7 @@ class PostgreSQL(Database):
             else:
                 dbcur.execute(command)
         except psycopg2.Error as e:
-            log.debug(str(e))
+            logger.debug(str(e))
             dbcur.execute("ROLLBACK")
             return False
         dbcur.close()
@@ -520,9 +519,9 @@ class PostgreSQL(Database):
                    tree=excluded.tree;"""
             .format(Settings.opera_session_data_table), (str(deployment_id), timestamp, tree_str))
         if response:
-            log.info('Updated dot_opera_data in PostgreSQL database')
+            logger.info('Updated dot_opera_data in PostgreSQL database')
         else:
-            log.error('Failed to update dot_opera_data in PostgreSQL database')
+            logger.error('Failed to update dot_opera_data in PostgreSQL database')
         return response
 
     def get_opera_session_data(self, deployment_id):
@@ -552,9 +551,9 @@ class PostgreSQL(Database):
             "delete from {} where deployment_id = '{}'"
             .format(Settings.opera_session_data_table, str(deployment_id)))
         if response:
-            log.info(f'Deleted opera_session_data for {deployment_id} from PostgreSQL database')
+            logger.info(f'Deleted opera_session_data for {deployment_id} from PostgreSQL database')
         else:
-            log.error(f'Failed to delete opera_session_data for {deployment_id} from PostgreSQL database')
+            logger.error(f'Failed to delete opera_session_data for {deployment_id} from PostgreSQL database')
         return response
 
     def update_deployment_log(self, invocation_id: uuid, inv: Invocation):
@@ -572,9 +571,9 @@ class PostgreSQL(Database):
              str(invocation_id), str(inv.blueprint_id),
              inv.version_id, json.dumps(inv.to_dict(), cls=file_util.UUIDEncoder)))
         if response:
-            log.info('Updated deployment log in PostgreSQL database')
+            logger.info('Updated deployment log in PostgreSQL database')
         else:
-            log.error('Failed to update deployment log in PostgreSQL database')
+            logger.error('Failed to update deployment log in PostgreSQL database')
         return response
 
     def get_deployment_status(self, deployment_id: uuid):
@@ -640,9 +639,9 @@ class PostgreSQL(Database):
             values (%s, %s, %s, %s, %s, %s, %s)""".format(Settings.git_log_table),
             (str(blueprint_id), version_id, revision_msg, job, git_backend, repo_url, commit_sha))
         if response:
-            log.info('Updated git log in PostgreSQL database')
+            logger.info('Updated git log in PostgreSQL database')
         else:
-            log.error('Fail to update git log in PostgreSQL database')
+            logger.error('Fail to update git log in PostgreSQL database')
         return response
 
     def get_git_transaction_data(self, blueprint_id: uuid, version_id: str = None, fetch_all: bool = False):
@@ -705,9 +704,9 @@ class PostgreSQL(Database):
             "insert into {} (blueprint_id, project_domain) values (%s, %s)"
                 .format(Settings.project_domain_table), (str(blueprint_id), project_domain))
         if response:
-            log.info('Updated {} in PostgreSQL database'.format(Settings.project_domain_table))
+            logger.info('Updated {} in PostgreSQL database'.format(Settings.project_domain_table))
         else:
-            log.error('Failed to update {} in PostgreSQL database'.format(Settings.project_domain_table))
+            logger.error('Failed to update {} in PostgreSQL database'.format(Settings.project_domain_table))
         return response
 
 

--- a/src/opera/api/util/xopera_util.py
+++ b/src/opera/api/util/xopera_util.py
@@ -1,5 +1,4 @@
 import grp
-import logging as log
 import os
 import pwd
 import re
@@ -11,6 +10,10 @@ import connexion
 import yaml
 
 from opera.api.settings import Settings
+from opera.api.log import get_logger
+
+
+logger = get_logger(__name__)
 
 
 @contextmanager
@@ -26,20 +29,20 @@ def cwd(path):
 def configure_ssh_keys():
     keys = list(Settings.ssh_keys_location.glob("*xOpera*"))
     if len(keys) != 2:
-        log.error(
+        logger.error(
             "Expected exactly 2 keys (public and private) with xOpera substring in name, found {}".format(len(keys)))
         return
     try:
         private_key = [str(key) for key in keys if ".pubk" not in str(key)][0]
         public_key = [str(key) for key in keys if ".pubk" in str(key)][0]
     except IndexError:
-        log.error(
+        logger.error(
             'Wrong file extension. Public key should have ".pubk" and private key should have ".pk" or no extension '
             'at all')
         return
     public_key_check = private_key.replace(".pk", "") + ".pubk"
     if public_key != public_key_check:
-        log.error(
+        logger.error(
             'No matching private and public key pair. Public key should have ".pubk" and private key should have '
             '".pk" or no extension at all')
         return
@@ -67,7 +70,7 @@ def configure_ssh_keys():
 
     key_pair = private_key_new.split("/")[-1]
     Settings.key_pair = key_pair
-    log.info("key '{}' added".format(Settings.key_pair))
+    logger.info("key '{}' added".format(Settings.key_pair))
 
 
 def init_dir(dir_path: str, clean=False):


### PR DESCRIPTION
A part of several context managers in the security controller is to check if blueprint_exists, which is usually done with API call to git (GitLab, GitHub,...). This approach has two issues: (1) it is rather slow and (2) if git is down, it does not work. This edge case disables the user to inspect invocation status or history for past deploy.

This contribution introduces 2 features:
- version_exists function in sql_db service, which determines (from git logs in sql_db) if blueprint_version exists
- security_controller 2 step version_exists check: first it checks in sql_db and then in git_db


Closes #86 