### PR TITLE
Instance state and current stdout in Invocation object

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       XOPERA_DATABASE_USER: postgres
       XOPERA_DATABASE_PASSWORD: password
       AUTH_API_KEY: test
+      PYTHONUNBUFFERED: 1
     volumes:
     - "/var/run/docker.sock:/var/run/docker.sock"
     - "/root/.ssh/:/root/.ssh/"

--- a/src/opera/api/controllers/background_invocation.py
+++ b/src/opera/api/controllers/background_invocation.py
@@ -317,6 +317,8 @@ class InvocationService:
             if inv.state == InvocationState.IN_PROGRESS:
                 inv.stdout = InvocationWorkerProcess.read_file(cls.stdout_file(inv.deployment_id))
                 inv.stderr = InvocationWorkerProcess.read_file(cls.stderr_file(inv.deployment_id))
+                location = InvocationService.deployment_location(inv.deployment_id, inv.blueprint_id)
+                inv.instance_state = InvocationService.get_instance_state(location)
             return inv
 
         except BaseException as e:

--- a/xOpera-rest-blueprint/inputs/input.yaml.tmpl
+++ b/xOpera-rest-blueprint/inputs/input.yaml.tmpl
@@ -29,6 +29,7 @@ postgres_env:
 xopera_env:
   DEBUG: "${xopera_debug}"
   LOG_LEVEL: ${xopera_log_level}
+  PYTHONUNBUFFERED: "1"
   # OIDC SETTINGS
   OIDC_INTROSPECTION_ENDPOINT: ${oidc_endpoint}
   OIDC_CLIENT_SECRET: ${oidc_secret}

--- a/xOpera-rest-blueprint/service.yaml
+++ b/xOpera-rest-blueprint/service.yaml
@@ -214,7 +214,7 @@ topology_template:
       properties:
         alias: xopera-rest-api
         docker_network_name:  { get_property: [ SELF, network, name ] }
-        image_name: xopera-rest-api
+        image_name: xopera-rest-api:latest
         restart_policy: always
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
This contribution enables xOpera REST API to add real-time instance_state and stdout in /status response.

This is implemented due to #90, but does not fully fixes it. 

@kmlTE , what do you think? Number of current nodes is a bit hard to implement at the moment, is this satisfactory?