### PR TITLE
Support multiple concurrent orchestration jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,7 @@ pipeline {
        // XOPERA SETTINGS
        xopera_debug = "false"
        xopera_log_level = "debug"
+       invocation_service_workers = '10'
        // OIDC secrets
        oidc_endpoint = credentials('oidc-endpoint')
        oidc_secret = credentials('oidc-secret')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       XOPERA_DATABASE_PASSWORD: password
       AUTH_API_KEY: test
       PYTHONUNBUFFERED: 1
+      INVOCATION_SERVICE_WORKERS: 10
     volumes:
     - "/var/run/docker.sock:/var/run/docker.sock"
     - "/root/.ssh/:/root/.ssh/"

--- a/src/opera/api/controllers/background_invocation.py
+++ b/src/opera/api/controllers/background_invocation.py
@@ -253,6 +253,13 @@ class InvocationWorkerProcess:
 class InvocationService:
 
     def __init__(self, workers_num=10):
+        """
+        Initializes InvocationService
+
+        It creates work_queue for invocations and workers_pool with [workers_num] workers
+        Args:
+            workers_num: number of workers
+        """
         self.work_queue: multiprocessing.Queue = multiprocessing.Queue()
         self.workers_pool = multiprocessing.Pool(workers_num, InvocationWorkerProcess.run_internal, (self.work_queue, ))
 

--- a/src/opera/api/controllers/background_invocation.py
+++ b/src/opera/api/controllers/background_invocation.py
@@ -32,17 +32,10 @@ from opera.api.util import xopera_util, file_util
 logger = get_logger(__name__)
 
 
-class InvocationWorkerProcess(multiprocessing.Process):
-
-    def __init__(self, work_queue: multiprocessing.Queue):
-        super(InvocationWorkerProcess, self).__init__(
-            group=None, target=self._run_internal, name="Invocation-Worker", args=(),
-            kwargs={
-                "work_queue": work_queue,
-            }, daemon=None)
+class InvocationWorkerProcess:
 
     @staticmethod
-    def _run_internal(work_queue: multiprocessing.Queue):
+    def run_internal(work_queue: multiprocessing.Queue):
 
         while True:
             inv: Invocation = work_queue.get(block=True)
@@ -259,10 +252,9 @@ class InvocationWorkerProcess(multiprocessing.Process):
 
 class InvocationService:
 
-    def __init__(self):
+    def __init__(self, workers_num=10):
         self.work_queue: multiprocessing.Queue = multiprocessing.Queue()
-        self.worker = InvocationWorkerProcess(self.work_queue)
-        self.worker.start()
+        self.workers_pool = multiprocessing.Pool(workers_num, InvocationWorkerProcess.run_internal, (self.work_queue, ))
 
     def invoke(self, operation_type: OperationType, blueprint_id: uuid, version_id: uuid,
                deployment_id: uuid, workers: int, inputs: dict,

--- a/src/opera/api/controllers/deployment_controller.py
+++ b/src/opera/api/controllers/deployment_controller.py
@@ -7,9 +7,10 @@ from opera.api.openapi.models import InvocationState
 from opera.api.openapi.models import OperationType, Invocation
 from opera.api.openapi.models.deployment_exists import DeploymentExists
 from opera.api.util import xopera_util
+from opera.api.settings import Settings
 
 logger = get_logger(__name__)
-invocation_service = InvocationService()
+invocation_service = InvocationService(workers_num=Settings.invocation_service_workers)
 
 
 def deployment_exists(blueprint_id, version_id=None, inputs_file=None):

--- a/src/opera/api/settings/settings.py
+++ b/src/opera/api/settings/settings.py
@@ -21,6 +21,9 @@ class Settings:
     INVOCATION_DIR = f"{API_WORKDIR}/invocations"
     DEPLOYMENT_DIR = f"{API_WORKDIR}/deployment_dir"
 
+    # maximum number of invocations at the same time
+    invocation_service_workers = 10
+
     # sql_database config
     sql_config = None
     invocation_table = 'invocation'
@@ -44,7 +47,7 @@ class Settings:
     vault_login_uri = None
     apiKey = None
     connection_protocols = ["http://", "https://"]
-    vault_secret_prefix =  "_get_secret"
+    vault_secret_prefix = "_get_secret"
 
 
     @staticmethod
@@ -77,6 +80,8 @@ class Settings:
         Settings.oidc_client_secret = os.getenv("OIDC_CLIENT_SECRET", "")
         Settings.apiKey = os.getenv("AUTH_API_KEY", "")
 
+        Settings.invocation_service_workers = int(os.getenv("INVOCATION_SERVICE_WORKERS", '10'))
+
         Settings.vault_secret_storage_uri = os.getenv("VAULT_SECRET_URI", "http://localhost:8200/v1/")
         Settings.vault_login_uri = os.getenv("VAULT_LOGIN_URI", "http://localhost:8200/v1/auth/jwt/login")
 
@@ -87,6 +92,11 @@ class Settings:
         __debug_git_config['mock_workdir'] = str(__debug_git_config['mock_workdir'])
 
         logger.debug(json.dumps({
+            "oidc_endpoint": Settings.oidc_introspection_endpoint_uri,
+            "oidc_client_id": Settings.oidc_client_id,
+            "oidc_client_secret": Settings.oidc_client_secret,
+            "auth_api_key": Settings.apiKey,
+            "invocation_service_workers": Settings.invocation_service_workers,
             "sql_config": Settings.sql_config,
             "git_config": __debug_git_config
         }, indent=2))

--- a/src/opera/api/util/xopera_util.py
+++ b/src/opera/api/util/xopera_util.py
@@ -90,7 +90,7 @@ def init_data():
 def get_preprocessed_inputs():
     raw_inputs = inputs_file()
     if raw_inputs:
-       return preprocess_inputs(raw_inputs, get_access_token())
+        return preprocess_inputs(raw_inputs, get_access_token())
     return None    
 
 

--- a/xOpera-rest-blueprint/inputs/input.yaml.tmpl
+++ b/xOpera-rest-blueprint/inputs/input.yaml.tmpl
@@ -30,6 +30,7 @@ xopera_env:
   DEBUG: "${xopera_debug}"
   LOG_LEVEL: ${xopera_log_level}
   PYTHONUNBUFFERED: "1"
+  INVOCATION_SERVICE_WORKERS: "${invocation_service_workers}"
   # OIDC SETTINGS
   OIDC_INTROSPECTION_ENDPOINT: ${oidc_endpoint}
   OIDC_CLIENT_SECRET: ${oidc_secret}


### PR DESCRIPTION
This contribution enables xOpera REST API to run multiple orchestration jobs at the same time. 

It does so by making it possible for InvocationService to employ an arbitrarily sized pool of workers instead of relying on just one.
 