### PR TITLE
Deployment Governance View

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -3,10 +3,10 @@
 set -e
 set -u
 
-[ -f openapi-generator-cli-4.3.0.jar ] || wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.0/openapi-generator-cli-4.3.0.jar
+[ -f openapi-generator-cli-5.1.1.jar ] || wget https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.1.1/openapi-generator-cli-5.1.1.jar
 rm -rf gen/
 rm -rf src/opera/api/openapi/
-java -jar openapi-generator-cli-4.3.0.jar generate \
+java -jar openapi-generator-cli-5.1.1.jar generate \
     --input-spec openapi-spec.yml \
     --api-package api \
     --invoker-package invoker \

--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -98,7 +98,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Blueprint'
+                $ref: '#/components/schemas/BlueprintVersion'
         401:
           description: Unauthorized request for this blueprint
           content:
@@ -148,8 +148,7 @@ paths:
                 type: array
                 description: List of blueprints for current user or project_domain
                 items:
-                  type: string
-                  format: uuid
+                  $ref: '#/components/schemas/Blueprint'
         400:
           description: Invalid request
           content:
@@ -217,7 +216,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Blueprint'
+                $ref: '#/components/schemas/BlueprintVersion'
         401:
           description: Unauthorized request for this blueprint
           content:
@@ -263,7 +262,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Blueprint'
+                $ref: '#/components/schemas/BlueprintVersion'
         401:
           description: Unauthorized request for this blueprint
           content:
@@ -318,7 +317,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Blueprint'
+                $ref: '#/components/schemas/BlueprintVersion'
         401:
           description: Unauthorized request for this blueprint
           content:
@@ -361,7 +360,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Blueprint'
+                $ref: '#/components/schemas/BlueprintVersion'
         401:
           description: Unauthorized request for this blueprint
           content:
@@ -411,7 +410,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Blueprint'
+                $ref: '#/components/schemas/BlueprintVersion'
         401:
           description: Unauthorized request for this blueprint
           content:
@@ -1382,6 +1381,33 @@ components:
           type: string
           description: Rest api's public key
     Blueprint:
+      type: object
+      required:
+        - blueprint_id
+        - timestamp
+      properties:
+        blueprint_id:
+          type: string
+          format: uuid
+          description: Id of blueprint
+        blueprint_name:
+          type: string
+          description: Name of the blueprint
+        aadm_id:
+          type: string
+          description: End-to-end debugging id
+        username:
+          type: string
+          description: Username of user, that created blueprint
+        project_domain:
+          type: string
+          description: Domain name of the blueprint
+        timestamp:
+          type: string
+          description: timestamp of database entry
+          format: date-time
+
+    BlueprintVersion:
       required:
         - blueprint_id
         - timestamp

--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -59,9 +59,19 @@ paths:
         description: Optional comment on submission
         schema:
           type: string
-      - name: name
+      - name: blueprint_name
         in: query
         description: Optional human-readable blueprint name
+        schema:
+          type: string
+      - name: aadm_id
+        in: query
+        description: End-to-end debugging id
+        schema:
+          type: string
+      - name: username
+        in: query
+        description: End-to-end debugging id
         schema:
           type: string
       - name: project_domain
@@ -820,7 +830,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/GitLog'
-        400:
+        404:
           description: Log file not found
           content:
             application/json:
@@ -909,6 +919,11 @@ paths:
         schema:
           type: string
           pattern: '^v(0|[1-9][0-9]*).(0|[1-9][0-9]*)$'
+      - name: deployment_label
+        in: query
+        description: Human-readable deployment label
+        schema:
+          type: string
       - name: workers
         in: query
         description: Number of workers
@@ -1323,9 +1338,15 @@ components:
           type: string
           pattern: '^v(0|[1-9][0-9]*).(0|[1-9][0-9]*)$'
           description: Id of blueprint version
-        name:
+        blueprint_name:
           type: string
           description: Name of the blueprint
+        aadm_id:
+          type: string
+          description: End-to-end debugging id
+        username:
+          type: string
+          description: Username of user, that created blueprint
         project_domain:
           type: string
           description: Domain name of the blueprint
@@ -1337,19 +1358,9 @@ components:
           type: string
           description: timestamp of database entry
           format: date-time
-        users:
-          type: array
-          description: List of users with access to git repository
-          items:
-            type: string
         commit_sha:
           type: string
           description: SHA-1 checksum of commit
-        deployments:
-          type: array
-          description: List of deployments from current blueprint
-          items:
-            $ref: '#/components/schemas/Deployment'
 
     GitLog:
       required:
@@ -1409,6 +1420,9 @@ components:
           description: Id of deployment
           type: string
           format: uuid
+        deployment_label:
+          type: string
+          description: Human-readable deployment name
         state:
           description: State of last invocation
           $ref: "#/components/schemas/InvocationState"
@@ -1444,6 +1458,9 @@ components:
           description: Id of deployment
           type: string
           format: uuid
+        deployment_label:
+          description: Human-readable deployment name
+          type: string
         state:
           $ref: "#/components/schemas/InvocationState"
         operation:

--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -118,6 +118,64 @@ paths:
               schema:
                 type: string
 
+    get:
+      summary: "Get blueprints for user or project domain"
+      security:
+        - apiKey: [ ]
+        - oauth2: [ email ]
+      tags:
+        - blueprint
+      operationId: get_blueprints_user_domain
+      parameters:
+        - name: username
+          in: query
+          description: username
+          required: false
+          schema:
+            type: string
+        - name: project_domain
+          in: query
+          description: Project domain
+          required: false
+          schema:
+            type: string
+      responses:
+        200:
+          description: List of blueprints returned
+          content:
+            application/json:
+              schema:
+                type: array
+                description: List of blueprints for current user or project_domain
+                items:
+                  type: string
+                  format: uuid
+        400:
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                type: string
+        401:
+          description: Unauthorized request for this blueprint
+          content:
+            application/json:
+              schema:
+                type: string
+        404:
+          description: User or project domain not found
+          content:
+            application/json:
+              schema:
+                type: string
+        500:
+          description: DB or REST API error
+          content:
+            application/json:
+              schema:
+                type: string
+
+
   /blueprint/{blueprint_id}:
     post:
       summary: "Add new version to existing blueprint."

--- a/src/opera/api/controllers/background_invocation.py
+++ b/src/opera/api/controllers/background_invocation.py
@@ -3,13 +3,12 @@ import json
 import multiprocessing
 import os
 import shutil
+import sys
 import tempfile
 import traceback
 import uuid
-import sys
 from pathlib import Path
 from typing import Optional
-from werkzeug.datastructures import FileStorage
 
 from opera.commands.deploy import deploy_service_template as opera_deploy
 from opera.commands.diff import diff_instances as opera_diff_instances
@@ -21,9 +20,10 @@ from opera.compare.instance_comparer import InstanceComparer as opera_InstanceCo
 from opera.compare.template_comparer import TemplateComparer as opera_TemplateComparer
 from opera.error import ParseError
 from opera.storage import Storage
+from werkzeug.datastructures import FileStorage
 
-from opera.api.blueprint_converters.blueprint2CSAR import entry_definitions
 from opera.api.blueprint_converters import csar_to_blueprint
+from opera.api.blueprint_converters.blueprint2CSAR import entry_definitions
 from opera.api.cli import CSAR_db, SQL_database
 from opera.api.log import get_logger
 from opera.api.openapi.models import Invocation, InvocationState, OperationType

--- a/src/opera/api/controllers/background_invocation.py
+++ b/src/opera/api/controllers/background_invocation.py
@@ -253,7 +253,7 @@ class InvocationWorkerProcess:
                     opera_validate(service_template, inputs)
                 return None
         except Exception as e:
-            return "{}: {}".format(e.__class__.__name__, xopera_util.mask_workdirs([location, csar_workdir], str(e)),)
+            return "{}: {}".format(e.__class__.__name__, xopera_util.mask_workdirs([location, csar_workdir], str(e)), )
 
     @staticmethod
     def outputs(deployment_id: str):
@@ -287,11 +287,11 @@ class InvocationService:
             workers_num: number of workers
         """
         self.work_queue: multiprocessing.Queue = multiprocessing.Queue()
-        self.workers_pool = multiprocessing.Pool(workers_num, InvocationWorkerProcess.run_internal, (self.work_queue, ))
+        self.workers_pool = multiprocessing.Pool(workers_num, InvocationWorkerProcess.run_internal, (self.work_queue,))
 
     def invoke(self, operation_type: OperationType, blueprint_id: uuid, version_id: uuid,
-               deployment_id: uuid, workers: int, inputs: dict,
-               clean_state: bool = None) -> Invocation:
+               workers: int, inputs: dict, deployment_id: uuid = None,
+               clean_state: bool = None, deployment_label: str = None) -> Invocation:
         now = datetime.datetime.now(tz=datetime.timezone.utc)
         logger.info("Invoking %s with ID %s at %s", operation_type, deployment_id, now.isoformat())
 
@@ -299,6 +299,7 @@ class InvocationService:
 
         inv = Invocation()
         inv.blueprint_id = blueprint_id
+        inv.deployment_label = deployment_label
         inv.version_id = version_id or CSAR_db.get_last_tag(blueprint_id)
         inv.deployment_id = deployment_id or uuid.uuid4()
         inv.state = InvocationState.PENDING

--- a/src/opera/api/controllers/blueprint_controller.py
+++ b/src/opera/api/controllers/blueprint_controller.py
@@ -10,22 +10,90 @@ from opera.api.util import timestamp_util
 logger = get_logger(__name__)
 
 
+def post_new_blueprint(revision_msg=None, blueprint_name=None, aadm_id=None, username=None, project_domain=None):  # noqa: E501
+    """Add new blueprint.
+
+    :param revision_msg: Optional comment on submission
+    :type revision_msg: str
+    :param blueprint_name: Optional human-readable blueprint name
+    :type blueprint_name: str
+    :param aadm_id: End-to-end debugging id
+    :type aadm_id: str
+    :param username: End-to-end debugging id
+    :type username: str
+    :param project_domain: Optional project domain this blueprint belongs to
+    :type project_domain: str
+
+    :rtype: Blueprint
+    """
+    # check roles
+    if project_domain and not security_controller.check_roles(project_domain):
+        return f"Unauthorized request for project: {project_domain}", 401
+
+    file = connexion.request.files['CSAR']
+
+    result, response = CSAR_db.add_revision(CSAR=file, revision_msg=revision_msg)
+
+    if result is None:
+        return f"Invalid CSAR: {response}", 406
+
+    blueprint_meta = Blueprint.from_dict(result)
+
+    blueprint_meta.blueprint_name = blueprint_name
+    blueprint_meta.project_domain = project_domain
+    blueprint_meta.aadm_id = aadm_id
+    blueprint_meta.username = username
+
+    if not SQL_database.save_blueprint_meta(blueprint_meta):
+        blueprint_id = blueprint_meta.blueprint_id
+        return f"Failed to save project data for blueprint_id={blueprint_id}", 500
+
+    SQL_database.save_git_transaction_data(blueprint_id=result['blueprint_id'],
+                                           version_id=result['version_id'],
+                                           revision_msg=f"Saved new blueprint: {revision_msg}",
+                                           job='update',
+                                           git_backend=str(CSAR_db.connection.git_connector),
+                                           repo_url=result['url'],
+                                           commit_sha=result['commit_sha'])
+
+    return blueprint_meta, 201
+
+
 @security_controller.check_role_auth_blueprint
-def delete_git_user(blueprint_id, user_id):
-    """Delete user.
+def post_blueprint(blueprint_id, revision_msg=None):
+    """Add new version to existing blueprint.
 
     :param blueprint_id: Id of blueprint
-    :type blueprint_id: 
-    :param user_id: user_id to be removed from repository with blueprint
-    :type user_id: str
+    :type blueprint_id:
+    :param revision_msg: Optional comment on submission
+    :type revision_msg: str
 
-    :rtype: str
+    :rtype: Blueprint
     """
-    success, error_msg = CSAR_db.delete_blueprint_user(blueprint_id=blueprint_id, username=user_id)
-    if success:
-        return f"User {user_id} deleted", 200
+    file = connexion.request.files['CSAR']
 
-    return f"Could not delete user {user_id} from repository with blueprint_id '{blueprint_id}': {error_msg}", 500
+    result, response = CSAR_db.add_revision(CSAR=file, revision_msg=revision_msg, blueprint_id=blueprint_id)
+
+    if result is None:
+        return f"Invalid CSAR: {response}", 406
+
+    blueprint_meta = Blueprint.from_dict(result)
+
+    blueprint_meta.name = SQL_database.get_blueprint_name(blueprint_id)
+    blueprint_meta.project_domain = SQL_database.get_project_domain(blueprint_id)
+
+    if not SQL_database.save_blueprint_meta(blueprint_meta):
+        return f"Failed to save project data for blueprint_id={blueprint_id}", 500
+
+    SQL_database.save_git_transaction_data(blueprint_id=result['blueprint_id'],
+                                           version_id=result['version_id'],
+                                           revision_msg=f"Updated blueprint: {revision_msg}",
+                                           job='update',
+                                           git_backend=str(CSAR_db.connection.git_connector),
+                                           repo_url=result['url'],
+                                           commit_sha=result['commit_sha'])
+
+    return blueprint_meta, 201
 
 
 @security_controller.check_role_auth_blueprint
@@ -155,81 +223,18 @@ def post_git_user(blueprint_id, user_id):
 
 
 @security_controller.check_role_auth_blueprint
-def post_blueprint(blueprint_id, revision_msg=None):
-    """Add new version to existing blueprint.
+def delete_git_user(blueprint_id, user_id):
+    """Delete user.
 
     :param blueprint_id: Id of blueprint
     :type blueprint_id:
-    :param revision_msg: Optional comment on submission
-    :type revision_msg: str
+    :param user_id: user_id to be removed from repository with blueprint
+    :type user_id: str
 
-    :rtype: Blueprint
+    :rtype: str
     """
-    file = connexion.request.files['CSAR']
+    success, error_msg = CSAR_db.delete_blueprint_user(blueprint_id=blueprint_id, username=user_id)
+    if success:
+        return f"User {user_id} deleted", 200
 
-    result, response = CSAR_db.add_revision(CSAR=file, revision_msg=revision_msg, blueprint_id=blueprint_id)
-
-    if result is None:
-        return f"Invalid CSAR: {response}", 406
-
-    blueprint_meta = Blueprint.from_dict(result)
-
-    blueprint_meta.name = SQL_database.get_blueprint_name(blueprint_id)
-    blueprint_meta.project_domain = SQL_database.get_project_domain(blueprint_id)
-
-    if not SQL_database.save_blueprint_meta(blueprint_meta):
-        return f"Failed to save project data for blueprint_id={blueprint_id}", 500
-
-    SQL_database.save_git_transaction_data(blueprint_id=result['blueprint_id'],
-                                           version_id=result['version_id'],
-                                           revision_msg=f"Updated blueprint: {revision_msg}",
-                                           job='update',
-                                           git_backend=str(CSAR_db.connection.git_connector),
-                                           repo_url=result['url'],
-                                           commit_sha=result['commit_sha'])
-
-    return blueprint_meta, 201
-
-
-def post_new_blueprint(revision_msg=None, name=None, project_domain=None):
-    """Add new blueprint.
-
-    :param revision_msg: Optional comment on submission
-    :type revision_msg: str
-    :param name: Optional human-readable blueprint name
-    :type name: str
-    :param project_domain: Optional project domain this blueprint belongs to
-    :type project_domain: str
-
-    :rtype: Blueprint
-    """
-    # check roles
-    if project_domain and not security_controller.check_roles(project_domain):
-        return f"Unauthorized request for project: {project_domain}", 401
-
-    file = connexion.request.files['CSAR']
-
-    result, response = CSAR_db.add_revision(CSAR=file, revision_msg=revision_msg)
-
-    if result is None:
-        return f"Invalid CSAR: {response}", 406
-
-    blueprint_meta = Blueprint.from_dict(result)
-
-    blueprint_meta.name = name
-    blueprint_meta.project_domain = project_domain
-
-    if not SQL_database.save_blueprint_meta(blueprint_meta):
-        blueprint_id = blueprint_meta.blueprint_id
-        return f"Failed to save project data for blueprint_id={blueprint_id}", 500
-
-    SQL_database.save_git_transaction_data(blueprint_id=result['blueprint_id'],
-                                           version_id=result['version_id'],
-                                           revision_msg=f"Saved new blueprint: {revision_msg}",
-                                           job='update',
-                                           git_backend=str(CSAR_db.connection.git_connector),
-                                           repo_url=result['url'],
-                                           commit_sha=result['commit_sha'])
-
-    return blueprint_meta, 201
-
+    return f"Could not delete user {user_id} from repository with blueprint_id '{blueprint_id}': {error_msg}", 500

--- a/src/opera/api/controllers/blueprint_controller.py
+++ b/src/opera/api/controllers/blueprint_controller.py
@@ -59,6 +59,29 @@ def post_new_blueprint(revision_msg=None, blueprint_name=None, aadm_id=None, use
     return blueprint_meta, 201
 
 
+def get_blueprints_user_domain(username=None, project_domain=None):
+    """Get blueprints for user or project domain
+
+    :param username: username
+    :type username: str
+    :param project_domain: Project domain
+    :type project_domain: str
+
+    :rtype: List[str]
+    """
+    logger.debug(f"{username=}")
+    logger.debug(f"{project_domain=}")
+    if not username and not project_domain:
+        return "At least on of (user, project_domain) must be present", 400
+
+    data = SQL_database.get_blueprints_by_user_or_project(username=username, project_domain=project_domain)
+
+    if not data:
+        return "Blueprints not found", 404
+
+    return data, 200
+
+
 @security_controller.check_role_auth_blueprint
 def post_blueprint(blueprint_id, revision_msg=None):
     """Add new version to existing blueprint.

--- a/src/opera/api/controllers/blueprint_controller.py
+++ b/src/opera/api/controllers/blueprint_controller.py
@@ -70,8 +70,6 @@ def get_blueprints_user_domain(username=None, project_domain=None):
 
     :rtype: List[Blueprint]
     """
-    logger.debug(f"{username=}")
-    logger.debug(f"{project_domain=}")
     if not username and not project_domain:
         return "At least on of (user, project_domain) must be present", 400
 

--- a/src/opera/api/controllers/blueprint_meta_controller.py
+++ b/src/opera/api/controllers/blueprint_meta_controller.py
@@ -107,6 +107,3 @@ def get_git_log(blueprint_id):
     if not data:
         return "Log not found", 404
     return [GitLog.from_dict(item) for item in data], 200
-
-
-

--- a/src/opera/api/controllers/blueprint_meta_controller.py
+++ b/src/opera/api/controllers/blueprint_meta_controller.py
@@ -1,7 +1,7 @@
-from opera.api.cli import SQL_database, CSAR_db
+from opera.api.cli import SQL_database
 from opera.api.controllers import security_controller
 from opera.api.log import get_logger
-from opera.api.openapi.models import Blueprint, GitLog, Deployment
+from opera.api.openapi.models import BlueprintVersion, GitLog, Deployment
 
 logger = get_logger(__name__)
 
@@ -20,7 +20,7 @@ def get_blueprint_meta(blueprint_id):  # noqa: E501
     data = SQL_database.get_blueprint_meta(blueprint_id)
     if not data:
         return "Blueprint meta not found", 404
-    return Blueprint.from_dict(data), 200
+    return BlueprintVersion.from_dict(data), 200
 
 
 @security_controller.check_role_auth_blueprint
@@ -39,7 +39,7 @@ def get_blueprint_version_meta(blueprint_id, version_id):  # noqa: E501
     data = SQL_database.get_blueprint_meta(blueprint_id, version_id)
     if not data:
         return "Blueprint meta not found", 404
-    return Blueprint.from_dict(data), 200
+    return BlueprintVersion.from_dict(data), 200
 
 
 @security_controller.check_role_auth_blueprint

--- a/src/opera/api/controllers/blueprint_meta_controller.py
+++ b/src/opera/api/controllers/blueprint_meta_controller.py
@@ -20,7 +20,6 @@ def get_blueprint_meta(blueprint_id):  # noqa: E501
     data = SQL_database.get_blueprint_meta(blueprint_id)
     if not data:
         return "Blueprint meta not found", 404
-    data['users'] = CSAR_db.get_blueprint_user_list(blueprint_id)[0]
     return Blueprint.from_dict(data), 200
 
 
@@ -40,7 +39,6 @@ def get_blueprint_version_meta(blueprint_id, version_id):  # noqa: E501
     data = SQL_database.get_blueprint_meta(blueprint_id, version_id)
     if not data:
         return "Blueprint meta not found", 404
-    data['users'] = CSAR_db.get_blueprint_user_list(blueprint_id)[0]
     return Blueprint.from_dict(data), 200
 
 
@@ -92,7 +90,7 @@ def get_blueprint_deployments(blueprint_id):  # noqa: E501
     """
     data = SQL_database.get_deployments_for_blueprint(blueprint_id)
     if not data:
-        return "Deployments not found", 400
+        return "Deployments not found", 404
     return [Deployment.from_dict(item) for item in data], 200
 
 
@@ -107,7 +105,7 @@ def get_git_log(blueprint_id):
     """
     data = SQL_database.get_git_transaction_data(blueprint_id, fetch_all=True)
     if not data:
-        return "Log not found", 400
+        return "Log not found", 404
     return [GitLog.from_dict(item) for item in data], 200
 
 

--- a/src/opera/api/controllers/blueprint_meta_controller.py
+++ b/src/opera/api/controllers/blueprint_meta_controller.py
@@ -103,7 +103,7 @@ def get_git_log(blueprint_id):
 
     :rtype: List[GitLog]
     """
-    data = SQL_database.get_git_transaction_data(blueprint_id, fetch_all=True)
+    data = SQL_database.get_git_transaction_data(blueprint_id)
     if not data:
         return "Log not found", 404
     return [GitLog.from_dict(item) for item in data], 200

--- a/src/opera/api/controllers/deployment_controller.py
+++ b/src/opera/api/controllers/deployment_controller.py
@@ -78,20 +78,29 @@ def post_deploy_continue(deployment_id, workers=1, clean_state=False):
     if inv.state in [InvocationState.PENDING, InvocationState.IN_PROGRESS]:
         return f"Previous operation on this deployment still running", 403
 
-    result = invocation_service.invoke(OperationType.DEPLOY_CONTINUE, inv.blueprint_id, inv.version_id, deployment_id,
-                                       workers, inputs, clean_state)
+    result = invocation_service.invoke(
+        operation_type=OperationType.DEPLOY_CONTINUE,
+        blueprint_id=inv.blueprint_id,
+        version_id=inv.version_id,
+        deployment_id=deployment_id,
+        workers=workers,
+        inputs=inputs,
+        clean_state=clean_state
+    )
     logger.info(f"Deploying '{inv.blueprint_id}', version_id: {inv.version_id}")
     return result, 202
 
 
 @security_controller.check_role_auth_blueprint
-def post_deploy_fresh(blueprint_id, version_id=None, workers=1):
+def post_deploy_fresh(blueprint_id, version_id=None, deployment_label=None, workers=None):  # noqa: E501
     """Initialize deployment and deploy
 
     :param blueprint_id: Id of blueprint
-    :type blueprint_id: 
+    :type blueprint_id:
     :param version_id: version_tag to deploy
     :type version_id: str
+    :param deployment_label: Human-readable deployment label
+    :type deployment_label: str
     :param workers: Number of workers
     :type workers: int
 
@@ -99,9 +108,14 @@ def post_deploy_fresh(blueprint_id, version_id=None, workers=1):
     """
     inputs = xopera_util.get_preprocessed_inputs()
 
-    deployment_id = None
-    result = invocation_service.invoke(OperationType.DEPLOY_FRESH, blueprint_id, version_id, deployment_id,
-                                       workers, inputs)
+    result = invocation_service.invoke(
+        operation_type=OperationType.DEPLOY_FRESH,
+        blueprint_id=blueprint_id,
+        version_id=version_id,
+        deployment_label=deployment_label,
+        workers=workers,
+        inputs=inputs
+    )
     logger.info(f"Deploying '{blueprint_id}', version_id: {version_id}")
     return result, 202
 
@@ -144,8 +158,14 @@ def post_undeploy(deployment_id, workers=1):
     if inv.state in [InvocationState.PENDING, InvocationState.IN_PROGRESS]:
         return f"Previous operation on this deployment still running", 403
 
-    result = invocation_service.invoke(OperationType.UNDEPLOY, inv.blueprint_id, inv.version_id, deployment_id, workers,
-                                       inputs)
+    result = invocation_service.invoke(
+        operation_type=OperationType.UNDEPLOY,
+        blueprint_id=inv.blueprint_id,
+        version_id=inv.version_id,
+        deployment_id=deployment_id,
+        workers=workers,
+        inputs=inputs
+    )
     logger.info(f"Undeploying '{deployment_id}'")
     return result, 202
 
@@ -174,7 +194,13 @@ def post_update(deployment_id, blueprint_id, version_id=None, workers=1):
     if inv.state in [InvocationState.PENDING, InvocationState.IN_PROGRESS]:
         return f"Previous operation on this deployment still running", 403
 
-    result = invocation_service.invoke(OperationType.UPDATE, blueprint_id, version_id, deployment_id,
-                                       workers, inputs)
+    result = invocation_service.invoke(
+        operation_type=OperationType.UPDATE,
+        blueprint_id=blueprint_id,
+        version_id=version_id,
+        deployment_id=deployment_id,
+        workers=workers,
+        inputs=inputs
+    )
     logger.info(f"Updating '{deployment_id}' with blueprint '{blueprint_id}', version_id: {version_id}")
     return result, 202

--- a/src/opera/api/controllers/deployment_controller.py
+++ b/src/opera/api/controllers/deployment_controller.py
@@ -5,9 +5,9 @@ from opera.api.controllers.background_invocation import InvocationWorkerProcess
 from opera.api.log import get_logger
 from opera.api.openapi.models import InvocationState
 from opera.api.openapi.models import OperationType, Invocation
+from opera.api.settings import Settings
 # from opera.api.openapi.models.deployment_exists import DeploymentExists
 from opera.api.util import xopera_util
-from opera.api.settings import Settings
 
 logger = get_logger(__name__)
 invocation_service = InvocationService(workers_num=Settings.invocation_service_workers)

--- a/src/opera/api/controllers/security_controller.py
+++ b/src/opera/api/controllers/security_controller.py
@@ -1,10 +1,10 @@
 import functools
+import logging
 import re
+from base64 import b64encode
+
 import connexion
 import requests
-import logging
-
-from base64 import b64encode
 
 from opera.api.cli import CSAR_db, SQL_database
 from opera.api.settings import Settings
@@ -53,7 +53,7 @@ def token_info(access_token) -> dict:
         return json
     except Exception as e:
         logging.error(str(e))
-        return None            
+        return None
 
 
 def validate_scope(required_scopes, token_scopes) -> bool:
@@ -98,7 +98,8 @@ def check_role_auth_blueprint(func):
             return f"Authorization configuration error", 401
 
         version_id = kwargs.get("version_id")
-        if not SQL_database.version_exists(blueprint_id, version_id) and not CSAR_db.version_exists(blueprint_id, version_id):
+        if not SQL_database.version_exists(blueprint_id, version_id) and not CSAR_db.version_exists(blueprint_id,
+                                                                                                    version_id):
             return f"Did not find blueprint with id: {blueprint_id} and version_id: {version_id or 'any'}", 404
 
         project_domain = SQL_database.get_project_domain(blueprint_id)
@@ -137,7 +138,8 @@ def check_role_auth_deployment(func):
         if not inv:
             return f"Deployment with id: {deployment_id} does not exist", 404
 
-        if not SQL_database.version_exists(inv.blueprint_id, inv.version_id) and not CSAR_db.version_exists(inv.blueprint_id, inv.version_id):
+        if not SQL_database.version_exists(inv.blueprint_id, inv.version_id) and not CSAR_db.version_exists(
+                inv.blueprint_id, inv.version_id):
             return f"Did not find blueprint with id: {inv.blueprint_id} and version_id: {inv.version_id or 'any'}", 404
 
         project_domain = SQL_database.get_project_domain(inv.blueprint_id)
@@ -147,4 +149,3 @@ def check_role_auth_deployment(func):
         return func(*args, **kwargs)
 
     return wrapper_check_role_auth
-

--- a/src/opera/api/gitCsarDB/connectors.py
+++ b/src/opera/api/gitCsarDB/connectors.py
@@ -6,8 +6,8 @@ import git
 import gitlab
 from github import Github, GithubException
 from gitlab import Gitlab
-from opera.api.log import get_logger
 
+from opera.api.log import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/opera/api/service/csardb_service.py
+++ b/src/opera/api/service/csardb_service.py
@@ -8,9 +8,8 @@ from werkzeug.datastructures import FileStorage
 from opera.api import gitCsarDB
 from opera.api.blueprint_converters import csar_to_blueprint
 from opera.api.blueprint_converters.blueprint2CSAR import validate_csar
-from opera.api.util.timestamp_util import datetime_now_to_string
 from opera.api.log import get_logger
-
+from opera.api.util.timestamp_util import datetime_now_to_string
 
 logger = get_logger(__name__)
 

--- a/src/opera/api/service/sqldb_service.py
+++ b/src/opera/api/service/sqldb_service.py
@@ -546,7 +546,6 @@ class PostgreSQL(Database):
             )
             dbcur.execute(stmt)
             line = dbcur.fetchone()
-            logger.debug(f'{line=}')
             if not line:
                 return None
             name = line[1]

--- a/src/opera/api/service/sqldb_service.py
+++ b/src/opera/api/service/sqldb_service.py
@@ -273,7 +273,8 @@ class PostgreSQL(Database):
                 last_job = line[0]
                 if last_job == "delete":
                     # blueprint version has been deleted
-                    logger.debug(f"Blueprint-version {blueprint_id}/{version_id} has been deleted, does not exist any more")
+                    logger.debug(
+                        f"Blueprint-version {blueprint_id}/{version_id} has been deleted, does not exist any more")
                     return False
 
             # all checks have passed, blueprint (version) exists

--- a/src/opera/api/settings/settings.py
+++ b/src/opera/api/settings/settings.py
@@ -49,7 +49,6 @@ class Settings:
     connection_protocols = ["http://", "https://"]
     vault_secret_prefix = "_get_secret"
 
-
     @staticmethod
     def load_settings():
         Settings.git_config = {

--- a/src/opera/api/tests/conftest.py
+++ b/src/opera/api/tests/conftest.py
@@ -238,18 +238,19 @@ def generic_dir():
 @pytest.fixture
 def inputs_no_secret():
     inputs = {
-                "frontend-address": "14.15.11.12",
-                "user": "test_user"
-             }
+        "frontend-address": "14.15.11.12",
+        "user": "test_user"
+    }
 
     return inputs
+
 
 @pytest.fixture
 def inputs_with_secret():
     inputs = {
-                "frontend-address": "14.15.11.12",
-                "user": "test_user",
-                "_get_secret_ssh": "pds/ssh_key_slurm:pds"
-             }
+        "frontend-address": "14.15.11.12",
+        "user": "test_user",
+        "_get_secret_ssh": "pds/ssh_key_slurm:pds"
+    }
 
     return inputs

--- a/src/opera/api/tests/conftest.py
+++ b/src/opera/api/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from opera.api.cli import test
 from opera.api.gitCsarDB import GitCsarDB
 from opera.api.gitCsarDB.connectors import MockConnector
-from opera.api.openapi.models import Invocation, InvocationState, OperationType, Blueprint, Deployment
+from opera.api.openapi.models import Invocation, InvocationState, OperationType, BlueprintVersion, Deployment
 from opera.api.settings import Settings
 from opera.api.util import timestamp_util, xopera_util
 
@@ -44,8 +44,8 @@ def change_API_WORKDIR(new_workdir: str):
 
 
 @pytest.fixture()
-def generic_blueprint_meta() -> Blueprint:
-    blueprint_meta = Blueprint()
+def generic_blueprint_meta() -> BlueprintVersion:
+    blueprint_meta = BlueprintVersion()
     blueprint_meta.blueprint_id = str(uuid.uuid4())
     blueprint_meta.version_id = 'v1.0'
     blueprint_meta.blueprint_name = 'name'

--- a/src/opera/api/tests/conftest.py
+++ b/src/opera/api/tests/conftest.py
@@ -48,7 +48,9 @@ def generic_blueprint_meta() -> Blueprint:
     blueprint_meta = Blueprint()
     blueprint_meta.blueprint_id = str(uuid.uuid4())
     blueprint_meta.version_id = 'v1.0'
-    blueprint_meta.name = 'name'
+    blueprint_meta.blueprint_name = 'name'
+    blueprint_meta.aadm_id = str(uuid.uuid4())
+    blueprint_meta.username = 'username'
     blueprint_meta.project_domain = 'project_domain'
     blueprint_meta.url = 'https://github.com/torvalds/linux'
     blueprint_meta.commit_sha = 'd7c5303fbc8ac874ae3e597a5a0d3707dc0230b4'
@@ -61,6 +63,7 @@ def generic_deployment() -> Deployment:
     dep = Deployment()
     dep.deployment_id = str(uuid.uuid4())
     dep.state = InvocationState.SUCCESS
+    # dep.label = 'deployment_label'
     dep.operation = OperationType.DEPLOY_FRESH
     dep.timestamp = timestamp_util.datetime_now_to_string()
     return dep
@@ -70,6 +73,7 @@ def generic_deployment() -> Deployment:
 def generic_invocation():
     inv = Invocation()
     inv.state = InvocationState.PENDING
+    inv.deployment_label = 'TestDeployment'
     inv.blueprint_id = str(uuid.uuid4())
     inv.deployment_id = str(uuid.uuid4())
     inv.version_id = 'v1.0'

--- a/src/opera/api/tests/test_04_sqldb.py
+++ b/src/opera/api/tests/test_04_sqldb.py
@@ -1,7 +1,7 @@
 import datetime
+import json
 import logging
 import uuid
-import json
 
 import psycopg2
 from assertpy import assert_that
@@ -593,7 +593,8 @@ class TestGitTransactionData:
             commit_sha=self.git_log.commit_sha
         )).is_true()
 
-        assert_that(caplog.text).contains("Updated git log", str(self.git_log.blueprint_id), str(self.git_log.version_id))
+        assert_that(caplog.text).contains("Updated git log", str(self.git_log.blueprint_id),
+                                          str(self.git_log.version_id))
 
     def test_save_fail(self, mocker, monkeypatch, caplog):
         # test set up
@@ -621,7 +622,6 @@ class TestGitTransactionData:
 
 
 class TestInvocation:
-
     inv = Invocation(
         deployment_id=str(uuid.uuid4()),
         deployment_label='label',

--- a/src/opera/api/tests/test_06_util.py
+++ b/src/opera/api/tests/test_06_util.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import datetime
+from pathlib import Path
 
 from assertpy import assert_that
 from pytest_mock import mocker as Mock
@@ -69,7 +69,8 @@ class TestXoperaUtil:
             '~/projects/SODALITE/SODALITE-EU-github/xopera-rest-api-2',
         ]
         stacktrace = f"Exception: {workdirs[0]} does not exist, also {workdirs[1]} is missing. {workdirs[2]} is ok."
-        assert_that(xopera_util.mask_workdirs([Path(workdir) for workdir in workdirs], stacktrace)).does_not_contain(*workdirs)
+        assert_that(xopera_util.mask_workdirs([Path(workdir) for workdir in workdirs], stacktrace)).does_not_contain(
+            *workdirs)
 
     def test_configure_ssh_keys_too_many(self, mock_ssh_keys_loc: Path, mocker: Mock, caplog):
         # mock os.chown func

--- a/src/opera/api/tests/test_09_blueprint.py
+++ b/src/opera/api/tests/test_09_blueprint.py
@@ -49,10 +49,16 @@ class TestPostNew:
                 'users': ['xopera'],
                 'timestamp': timestamp_util.datetime_now_to_string()
             }, None))
-        resp = client.post("/blueprint", data=csar_1)
+        revision_msg = 'Another blueprint'
+        name = 'Test blueprint'
+        aadm_id = str(uuid.uuid4())
+        username = 'mihaTrajbaric'
+        project_domain = 'SODALITE'
+        resp = client.post(f"/blueprint?revision_msg={revision_msg}&blueprint_name={name}&aadm_id={aadm_id}"
+                           f"&username={username}&project_domain={project_domain}", data=csar_1)
         assert_that(resp.status_code).is_equal_to(201)
-        assert_that(resp.json).is_not_none().contains_only('blueprint_id', 'url',
-                                                           'version_id', 'users', 'commit_sha', 'timestamp')
+        assert_that(resp.json).is_not_none().contains_only('blueprint_id', 'version_id', 'blueprint_name', 'aadm_id', 'url',
+                                                           'project_domain', 'username', 'commit_sha', 'timestamp')
         uuid.UUID(resp.get_json()['blueprint_id'])
 
         assert_that(resp.get_json()['version_id']).is_equal_to('v1.0')
@@ -106,7 +112,7 @@ class TestPostMultipleVersions:
         resp2 = client.post(f"/blueprint/{uuid.uuid4()}", data=csar_1)
         assert_that(resp2.status_code).is_equal_to(201)
         assert_that(resp2.json).is_not_none().contains_only('blueprint_id', 'url', 'version_id',
-                                                            'users', 'commit_sha', 'timestamp')
+                                                            'commit_sha', 'timestamp')
         assert_that(resp2.json['version_id']).is_equal_to('v2.0')
 
 

--- a/src/opera/api/tests/test_09_blueprint.py
+++ b/src/opera/api/tests/test_09_blueprint.py
@@ -56,7 +56,8 @@ class TestPostNew:
         resp = client.post(f"/blueprint?revision_msg={revision_msg}&blueprint_name={name}&aadm_id={aadm_id}"
                            f"&username={username}&project_domain={project_domain}", data=csar_1)
         assert_that(resp.status_code).is_equal_to(201)
-        assert_that(resp.json).is_not_none().contains_only('blueprint_id', 'version_id', 'blueprint_name', 'aadm_id', 'url',
+        assert_that(resp.json).is_not_none().contains_only('blueprint_id', 'version_id', 'blueprint_name', 'aadm_id',
+                                                           'url',
                                                            'project_domain', 'username', 'commit_sha', 'timestamp')
         uuid.UUID(resp.get_json()['blueprint_id'])
 
@@ -314,7 +315,6 @@ class TestUser:
 class TestGetBlueprintByUserOrDomain:
 
     def test_missing_params(self, client, mocker, patch_auth_wrapper):
-
         resp = client.get(f"/blueprint")
         assert_that(resp.status_code).is_equal_to(400)
 
@@ -334,7 +334,8 @@ class TestGetBlueprintByUserOrDomain:
             "project_domain": 'SODALITE',
             "timestamp": timestamp_util.datetime_now_to_string()
         }]
-        mocker.patch('opera.api.service.sqldb_service.Database.get_blueprints_by_user_or_project', return_value=blueprints)
+        mocker.patch('opera.api.service.sqldb_service.Database.get_blueprints_by_user_or_project',
+                     return_value=blueprints)
         resp = client.get(f"/blueprint?username=foo")
         assert_that(resp.status_code).is_equal_to(200)
         assert_that(len(resp.json)).is_equal_to(1)

--- a/src/opera/api/tests/test_10_deployment.py
+++ b/src/opera/api/tests/test_10_deployment.py
@@ -39,13 +39,21 @@ class TestDeployFresh:
         blueprint_id = uuid.uuid4()
         version_id = 'v2.0'
         workers = 42
-        resp = client.post(f"/deployment/deploy?blueprint_id={blueprint_id}&version_id={version_id}&workers={workers}",
+        deployment_label = 'production'
+        resp = client.post(f"/deployment/deploy?blueprint_id={blueprint_id}&version_id={version_id}"
+                           f"&workers={workers}&deployment_label={deployment_label}",
                            data=inputs_1)
         assert resp.status_code == 202
         inv_dict = generic_invocation.to_dict()
         assert_that(resp.json).contains_only(*[k for k in inv_dict.keys() if inv_dict[k] is not None])
-        mock_invoke.assert_called_with(OperationType.DEPLOY_FRESH, str(blueprint_id), version_id, None, workers,
-                                       {'marker': 'blah'})
+        mock_invoke.assert_called_with(
+            operation_type=OperationType.DEPLOY_FRESH,
+            blueprint_id=str(blueprint_id),
+            version_id=version_id,
+            deployment_label=deployment_label,
+            workers=workers,
+            inputs={'marker': 'blah'}
+        )
 
     def test_no_inputs(self, client, mocker, generic_invocation):
         mock_invoke = mocker.MagicMock(name='invoke', return_value=generic_invocation)
@@ -55,7 +63,14 @@ class TestDeployFresh:
         blueprint_id = uuid.uuid4()
         resp = client.post(f"/deployment/deploy?blueprint_id={blueprint_id}")
         assert resp.status_code == 202
-        mock_invoke.assert_called_with('deploy_fresh', str(blueprint_id), None, None, 1, None)
+        mock_invoke.assert_called_with(
+            operation_type=OperationType.DEPLOY_FRESH,
+            blueprint_id=str(blueprint_id),
+            version_id=None,
+            deployment_label=None,
+            workers=1,
+            inputs=None
+        )
 
 
 class TestStatus:
@@ -172,8 +187,15 @@ class TestDeployContinue:
         assert resp.status_code == 202
         inv_dict = inv.to_dict()
         assert_that(resp.json).contains_only(*[k for k in inv_dict.keys() if inv_dict[k] is not None])
-        mock_invoke.assert_called_with(OperationType.DEPLOY_CONTINUE, str(inv.blueprint_id), inv.version_id,
-                                       str(inv.deployment_id), inv.workers, {'marker': 'blah'}, inv.clean_state)
+        mock_invoke.assert_called_with(
+            operation_type=OperationType.DEPLOY_CONTINUE,
+            blueprint_id=str(inv.blueprint_id),
+            version_id=inv.version_id,
+            deployment_id=str(inv.deployment_id),
+            workers=inv.workers,
+            inputs={'marker': 'blah'},
+            clean_state=inv.clean_state
+        )
 
 
 class TestDiff:
@@ -235,8 +257,14 @@ class TestUpdate:
         assert resp.status_code == 202
         inv_dict = inv.to_dict()
         assert_that(resp.json).contains_only(*[k for k in inv_dict.keys() if inv_dict[k] is not None])
-        mock_invoke.assert_called_with(OperationType.UPDATE, str(inv.blueprint_id), inv.version_id,
-                                       str(inv.deployment_id), inv.workers, {'marker': 'blah'})
+        mock_invoke.assert_called_with(
+            operation_type=OperationType.UPDATE,
+            blueprint_id=str(inv.blueprint_id),
+            version_id=inv.version_id,
+            deployment_id=str(inv.deployment_id),
+            workers=inv.workers,
+            inputs={'marker': 'blah'}
+        )
 
 
 class TestUndeploy:
@@ -264,5 +292,11 @@ class TestUndeploy:
         assert resp.status_code == 202
         inv_dict = inv.to_dict()
         assert_that(resp.json).contains_only(*[k for k in inv_dict.keys() if inv_dict[k] is not None])
-        mock_invoke.assert_called_with(OperationType.UNDEPLOY, str(inv.blueprint_id), inv.version_id,
-                                       str(inv.deployment_id), inv.workers, {'marker': 'blah'})
+        mock_invoke.assert_called_with(
+            operation_type=OperationType.UNDEPLOY,
+            blueprint_id=str(inv.blueprint_id),
+            version_id=inv.version_id,
+            deployment_id=str(inv.deployment_id),
+            workers=inv.workers,
+            inputs={'marker': 'blah'}
+        )

--- a/src/opera/api/tests/test_11_vault.py
+++ b/src/opera/api/tests/test_11_vault.py
@@ -1,8 +1,9 @@
-import pytest
-
 from unittest.mock import MagicMock
 
+import pytest
+
 from opera.api.util.vault_client import get_secret
+
 
 class TestVault:
 
@@ -10,19 +11,19 @@ class TestVault:
         with pytest.raises(ValueError):
             get_secret("", "", None)
 
-
     def test_get_secret(self, mocker):
         def get_json():
             return {
-                        "data":
-                        {
-                            "ssh_key": "test"
-                        }
+                "data":
+                    {
+                        "ssh_key": "test"
                     }
+            }
+
         get_response = MagicMock()
         get_response.json = get_json
         mocker.patch("opera.api.util.vault_client.session.get",
-                        return_value=get_response)
+                     return_value=get_response)
         mocker.patch("opera.api.util.vault_client.session.post")
         result = get_secret("pds/test", "pds", "ACCESS_TOKEN")
         assert len(result) == 1

--- a/src/opera/api/tests/test_16_security.py
+++ b/src/opera/api/tests/test_16_security.py
@@ -25,4 +25,3 @@ class TestSecurity:
         mock.json.return_value = {'scope': ['email']}
         result = security_controller.token_info("ACCESS_TOKEN")
         assert result["scope"][0] == 'email'
-

--- a/src/opera/api/tests/test_17_blueprint_meta.py
+++ b/src/opera/api/tests/test_17_blueprint_meta.py
@@ -160,4 +160,4 @@ class TestGitHistory:
         assert resp.status_code == 200
         assert_that(resp.json).is_length(1)
         assert_that(resp.json[0]).contains_only(*git_data.to_dict().keys())
-        mock_git_data.assert_called_with(git_data.blueprint_id, fetch_all=True)
+        mock_git_data.assert_called_with(git_data.blueprint_id)

--- a/src/opera/api/tests/test_17_blueprint_meta.py
+++ b/src/opera/api/tests/test_17_blueprint_meta.py
@@ -2,7 +2,7 @@ import uuid
 
 from assertpy import assert_that
 
-from opera.api.openapi.models import GitLog, Blueprint, Deployment, InvocationState, OperationType
+from opera.api.openapi.models import GitLog, BlueprintVersion, Deployment, InvocationState, OperationType
 from opera.api.util import timestamp_util
 
 
@@ -19,7 +19,7 @@ class TestBlueprintMeta:
 
     @staticmethod
     def test_success(client, mocker, generic_blueprint_meta, patch_auth_wrapper):
-        blueprint_meta: Blueprint = generic_blueprint_meta
+        blueprint_meta: BlueprintVersion = generic_blueprint_meta
         mocker.patch('opera.api.service.sqldb_service.Database.get_blueprint_meta', return_value=blueprint_meta.to_dict())
 
         blueprint_id = uuid.uuid4()
@@ -27,6 +27,7 @@ class TestBlueprintMeta:
         assert resp.status_code == 200
         print(blueprint_meta.to_dict())
         assert_that(resp.json).contains(*[key for key in blueprint_meta.to_dict().keys() if key is not None])
+
 
 class TestBlueprintVersionMeta:
 
@@ -40,7 +41,7 @@ class TestBlueprintVersionMeta:
 
     @staticmethod
     def test_success(client, mocker, generic_blueprint_meta, patch_auth_wrapper):
-        blueprint_meta: Blueprint = generic_blueprint_meta
+        blueprint_meta: BlueprintVersion = generic_blueprint_meta
         blueprint_meta.deployments = [
             Deployment(
                 str(uuid.uuid4()), InvocationState.SUCCESS,

--- a/src/opera/api/tests/test_17_blueprint_meta.py
+++ b/src/opera/api/tests/test_17_blueprint_meta.py
@@ -20,17 +20,12 @@ class TestBlueprintMeta:
     @staticmethod
     def test_success(client, mocker, generic_blueprint_meta, patch_auth_wrapper):
         blueprint_meta: Blueprint = generic_blueprint_meta
-        blueprint_meta.deployments = [
-            Deployment(
-                str(uuid.uuid4()), InvocationState.SUCCESS,
-                OperationType.DEPLOY_CONTINUE, timestamp_util.datetime_now_to_string()
-            )]
         mocker.patch('opera.api.service.sqldb_service.Database.get_blueprint_meta', return_value=blueprint_meta.to_dict())
-        mocker.patch('opera.api.service.csardb_service.GitDB.get_blueprint_user_list', return_value=[['foo'], None])
 
         blueprint_id = uuid.uuid4()
         resp = client.get(f"/blueprint/{blueprint_id}/meta")
         assert resp.status_code == 200
+        print(blueprint_meta.to_dict())
         assert_that(resp.json).contains(*[key for key in blueprint_meta.to_dict().keys() if key is not None])
 
 class TestBlueprintVersionMeta:
@@ -105,7 +100,7 @@ class TestGetDeployments:
                      return_value=[deployment.to_dict()])
         resp = client.get(f"/blueprint/{uuid.uuid4()}/deployments")
         assert resp.status_code == 200
-        assert_that(resp.json).is_equal_to([deployment.to_dict()])
+        assert_that(resp.json).is_equal_to([{k: v for k, v in deployment.to_dict().items() if v is not None}])
 
     @staticmethod
     def test_fail(mocker, client, patch_auth_wrapper):
@@ -113,7 +108,7 @@ class TestGetDeployments:
                      return_value=[])
 
         resp = client.get(f"/blueprint/{uuid.uuid4()}/deployments")
-        assert resp.status_code == 400
+        assert resp.status_code == 404
         assert_that(resp.json).contains('not found')
 
 
@@ -123,7 +118,7 @@ class TestGitHistory:
         mocker.patch('opera.api.service.sqldb_service.Database.get_git_transaction_data', return_value=None)
         blueprint_id = uuid.uuid4()
         resp = client.get(f"/blueprint/{blueprint_id}/git_history")
-        assert resp.status_code == 400
+        assert resp.status_code == 404
         assert_that(resp.json).contains('Log not found')
 
     def test_no_blueprint(self, client, mocker):

--- a/src/opera/api/tests/test_17_blueprint_meta.py
+++ b/src/opera/api/tests/test_17_blueprint_meta.py
@@ -20,7 +20,8 @@ class TestBlueprintMeta:
     @staticmethod
     def test_success(client, mocker, generic_blueprint_meta, patch_auth_wrapper):
         blueprint_meta: BlueprintVersion = generic_blueprint_meta
-        mocker.patch('opera.api.service.sqldb_service.Database.get_blueprint_meta', return_value=blueprint_meta.to_dict())
+        mocker.patch('opera.api.service.sqldb_service.Database.get_blueprint_meta',
+                     return_value=blueprint_meta.to_dict())
 
         blueprint_id = uuid.uuid4()
         resp = client.get(f"/blueprint/{blueprint_id}/meta")
@@ -47,7 +48,8 @@ class TestBlueprintVersionMeta:
                 str(uuid.uuid4()), InvocationState.SUCCESS,
                 OperationType.DEPLOY_CONTINUE, timestamp_util.datetime_now_to_string()
             )]
-        mocker.patch('opera.api.service.sqldb_service.Database.get_blueprint_meta', return_value=blueprint_meta.to_dict())
+        mocker.patch('opera.api.service.sqldb_service.Database.get_blueprint_meta',
+                     return_value=blueprint_meta.to_dict())
         mocker.patch('opera.api.service.csardb_service.GitDB.get_blueprint_user_list', return_value=[['foo'], None])
 
         resp = client.get(f"/blueprint/{uuid.uuid4()}/version/v1.0/meta")

--- a/src/opera/api/tests/test_18_validate.py
+++ b/src/opera/api/tests/test_18_validate.py
@@ -104,4 +104,3 @@ class TestValidateNew:
         assert resp.status_code == 200
         assert_that(resp.json).contains_only("blueprint_valid")
         assert_that(resp.json['blueprint_valid']).is_true()
-

--- a/src/opera/api/util/file_util.py
+++ b/src/opera/api/util/file_util.py
@@ -2,7 +2,6 @@ import json
 import pathlib
 import shutil
 from uuid import UUID
-from datetime import datetime
 
 
 def dir_to_json(dir_path: pathlib.Path) -> dict:
@@ -31,4 +30,3 @@ class UUIDEncoder(json.JSONEncoder):
             # if the obj is uuid, we simply return the value of uuid
             return str(obj)
         return json.JSONEncoder.default(self, obj)
-

--- a/src/opera/api/util/vault_client.py
+++ b/src/opera/api/util/vault_client.py
@@ -1,10 +1,10 @@
-import requests
 import urllib.parse
 
+import requests
 from requests.exceptions import ConnectionError
 
-from opera.api.settings import Settings
 from opera.api.log import get_logger
+from opera.api.settings import Settings
 
 adapter = requests.adapters.HTTPAdapter(pool_connections=100, pool_maxsize=100)
 session = requests.Session()
@@ -19,22 +19,22 @@ def get_secret(secret_path, vault_role, access_token) -> dict:
     if access_token is None:
         raise ValueError(
             "Vault secret retrieval error. Access token is not provided."
-            )
+        )
     request = {'jwt': access_token, 'role': vault_role}
     secret_vault_login_uri = Settings.vault_login_uri
     token_request = session.post(secret_vault_login_uri, data=request)
     if not token_request.ok:
         raise ConnectionError(
             "Vault auth error. {}".format(token_request.text)
-            )
+        )
     vault_token = token_request.json()['auth']['client_token']
     headers = {'X-Vault-Token': vault_token}
     secret_vault_uri = Settings.vault_secret_storage_uri
     secret_request = session.get(
         urllib.parse.urljoin(secret_vault_uri, secret_path), headers=headers
-        )
+    )
     if not secret_request.ok:
         raise ConnectionError(
             "Vault secret retrieval error. {}".format(secret_request.text)
-            )
+        )
     return secret_request.json()["data"]

--- a/src/opera/api/util/xopera_util.py
+++ b/src/opera/api/util/xopera_util.py
@@ -9,10 +9,9 @@ from pathlib import Path
 import connexion
 import yaml
 
-from opera.api.settings import Settings
 from opera.api.log import get_logger
+from opera.api.settings import Settings
 from opera.api.util.vault_client import get_secret
-
 
 logger = get_logger(__name__)
 
@@ -91,7 +90,7 @@ def get_preprocessed_inputs():
     raw_inputs = inputs_file()
     if raw_inputs:
         return preprocess_inputs(raw_inputs, get_access_token())
-    return None    
+    return None
 
 
 def inputs_file():
@@ -113,8 +112,8 @@ def preprocess_inputs(inputs, access_token):
                 raise ValueError(
                     "Incorrect input format for secret: {0}".format(
                         inputs[key]
-                        )
                     )
+                )
             secret = get_secret(path, role, access_token)
             if isinstance(secret, dict):
                 refined_inputs.pop(key)
@@ -124,8 +123,8 @@ def preprocess_inputs(inputs, access_token):
                     "Incorrect secret: {0} for role {1}".format(
                         path,
                         role
-                        )
                     )
+                )
 
     return refined_inputs
 


### PR DESCRIPTION
This PR supports Governance View

## API changes:
### New endpoints
- GET `/blueprint?user={username}` (obtain list of blueprints for specific user)
- GET `/blueprint?project_domain={project_domain}` (obtain list of blueprints for specific project)
### Changed endpoints
- New parameters in POST `/blueprint`
    - `name` -> `blueprint_name`
    - `aadm_id`
    - `username`
- New parameter in POST `/deployment/deploy` (`deployment_label`)

## Other changes
- Implement SQL injection prevention in PostgreSQL connector
- code cleanup
- Improved test coverage in sqldb_service 

Closes #107 