### PR TITLE
Add last_inputs to basic deployment info

### DIFF
--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -1513,6 +1513,11 @@ components:
         operation:
           description: Type of last invocation
           $ref: "#/components/schemas/OperationType"
+        last_inputs:
+          description: Inputs from last invocation.
+          type: object
+          additionalProperties:
+            type: string
         timestamp:
           description: An ISO8601 timestamp of when last job ended
           type: string

--- a/src/opera/api/service/sqldb_service.py
+++ b/src/opera/api/service/sqldb_service.py
@@ -680,7 +680,7 @@ class PostgreSQL(Database):
                 return None
             try:
                 return json.loads(line[0])
-            except json.decoder.JSONDecodeError:
+            except (json.decoder.JSONDecodeError, TypeError):
                 return None
 
     def get_deployments_for_blueprint(self, blueprint_id: uuid):
@@ -711,7 +711,7 @@ class PostgreSQL(Database):
                     'deployment_label': line[4]
                 } for line in lines
             ]
-            return deployment_list
+            return sorted(deployment_list, key=lambda x: x['timestamp'], reverse=True)
 
     def get_blueprints_by_user_or_project(self, username: str = None, project_domain: str = None):
         """

--- a/src/opera/api/service/sqldb_service.py
+++ b/src/opera/api/service/sqldb_service.py
@@ -145,6 +145,12 @@ class Database:
         """
         pass
 
+    def get_inputs(self, deployment_id: uuid):
+        """
+        extracts inputs from last invocation, belonging to deployment with this deployment_id
+        """
+        pass
+
     def get_deployments_for_blueprint(self, blueprint_id: uuid):
         """
         Returns [Deployment] for every deployment, created from blueprint
@@ -657,6 +663,26 @@ class PostgreSQL(Database):
 
         return success
 
+    def get_inputs(self, deployment_id: uuid):
+        """
+        extracts inputs from last invocation, belonging to deployment with this deployment_id
+        """
+        with self.connection.cursor() as dbcur:
+            stmt = sql.SQL("""select _log::json->>'inputs' from {invocation_table}
+                                where deployment_id = {deployment_id}
+                                order by timestamp desc limit 1""").format(
+                invocation_table=sql.Identifier(Settings.invocation_table),
+                deployment_id=sql.Literal(str(deployment_id))
+            )
+            dbcur.execute(stmt)
+            line = dbcur.fetchone()
+            if not line:
+                return None
+            try:
+                return json.loads(line[0])
+            except json.decoder.JSONDecodeError:
+                return None
+
     def get_deployments_for_blueprint(self, blueprint_id: uuid):
         """
         Returns [Deployment] for every deployment, created from blueprint
@@ -681,6 +707,7 @@ class PostgreSQL(Database):
                     'state': line[1],
                     'operation': line[2],
                     'timestamp': timestamp_util.datetime_to_str(line[3]),
+                    'last_inputs': self.get_inputs(line[0]),
                     'deployment_label': line[4]
                 } for line in lines
             ]


### PR DESCRIPTION
This pull request adds last inputs to basic deployment info, which is obtained from endpoint `/blueprint/{blueprint_id}/deployments`. This feature was required by [deployment governance view](https://github.com/SODALITE-EU/ide/issues/10) on [SODALITE IDE](https://github.com/SODALITE-EU/ide).