### PR TITLE
Active deployments and delete deployment

### DIFF
--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -537,6 +537,13 @@ paths:
           schema:
             type: string
             format: uuid
+        - name: active
+          in: query
+          description: Obtain only list of active deployments.
+          required: false
+          schema:
+            type: boolean
+            default: true
       responses:
         200:
           description: Deployments returned

--- a/openapi-spec.yml
+++ b/openapi-spec.yml
@@ -907,59 +907,6 @@ paths:
               schema:
                 type: string
 
-#  /deployment/exists:
-#    put:
-#      summary: "Check if deployment exists"
-#      security:
-#        - apiKey: []
-#        - oauth2: [email]
-#      tags:
-#      - deployment
-#      operationId: deployment_exists
-#      parameters:
-#      - name: blueprint_id
-#        in: query
-#        description: Id of blueprint
-#        required: true
-#        schema:
-#          type: string
-#          format: uuid
-#      - name: version_id
-#        in: query
-#        description: Id of blueprint version
-#        schema:
-#          type: string
-#          pattern: '^v(0|[1-9][0-9]*).(0|[1-9][0-9]*)$'
-#      requestBody:
-#        content:
-#          multipart/form-data:
-#            schema:
-#              type: object
-#              properties:
-#                inputs_file:
-#                  type: string
-#                  description: File with inputs TOSCA blueprint
-#                  format: binary
-#      responses:
-#        200:
-#          description: OK
-#          content:
-#            application/json:
-#              schema:
-#                $ref: '#/components/schemas/DeploymentExists'
-#        401:
-#          description: Unauthorized request for this blueprint
-#          content:
-#            application/json:
-#              schema:
-#                type: string
-#        404:
-#          description: Did not find blueprint
-#          content:
-#            application/json:
-#              schema:
-#                type: string
-
   /deployment/deploy:
     post:
       summary: "Initialize deployment and deploy"
@@ -1362,6 +1309,58 @@ paths:
               schema:
                 type: string
 
+  /deployment/{deployment_id}:
+    delete:
+      summary: "Delete all deployment data"
+      description: "This endpoint deletes all data, about deployment, that are stored on xOpera REST API. It does not
+      modify actual deployed instance. To undeploy actual instance, use /deployment/{deployment_id}/undeploy"
+      security:
+        - apiKey: [ ]
+        - oauth2: [ email ]
+      tags:
+        - deployment
+      operationId: delete_deployment
+      parameters:
+        - name: deployment_id
+          in: path
+          description: Id of deployment
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: Deployment deleted.
+          content:
+            application/json:
+              schema:
+                type: string
+        401:
+          description: Unauthorized request for this blueprint
+          content:
+            application/json:
+              schema:
+                type: string
+        403:
+          description: Not allowed, previous operation on deployment still running
+          content:
+            application/json:
+              schema:
+                type: string
+        404:
+          description: Did not find blueprint or deployment
+          content:
+            application/json:
+              schema:
+                type: string
+
+        500:
+          description: DB or REST API error
+          content:
+            application/json:
+              schema:
+                type: string
+
 components:
   schemas:
     BlueprintValidation:
@@ -1490,14 +1489,6 @@ components:
           type: string
           description: Id of version
           pattern: '^v(0|[1-9][0-9]*).(0|[1-9][0-9]*)$'
-
-#    DeploymentExists:
-#      type: object
-#      properties:
-#        exists:
-#          type: boolean
-#        checksum:
-#          type: string
 
     Deployment:
       type: object

--- a/src/opera/api/controllers/blueprint_meta_controller.py
+++ b/src/opera/api/controllers/blueprint_meta_controller.py
@@ -78,17 +78,19 @@ def post_blueprint_name(blueprint_id, name):  # noqa: E501
 
 
 @security_controller.check_role_auth_blueprint
-def get_blueprint_deployments(blueprint_id):  # noqa: E501
+def get_blueprint_deployments(blueprint_id, active=True):  # noqa: E501
     """Get deployments for current blueprint
 
      # noqa: E501
 
     :param blueprint_id: Id of blueprint
-    :type blueprint_id: 
+    :type blueprint_id:
+    :param active: Obtain only list of active deployments.
+    :type active: bool
 
     :rtype: List[Deployment]
     """
-    data = SQL_database.get_deployments_for_blueprint(blueprint_id)
+    data = SQL_database.get_deployments_for_blueprint(blueprint_id, active)
     if not data:
         return "Deployments not found", 404
     return [Deployment.from_dict(item) for item in data], 200

--- a/src/opera/api/service/sqldb_service.py
+++ b/src/opera/api/service/sqldb_service.py
@@ -67,6 +67,12 @@ class Database:
         """
         pass
 
+    def delete_opera_session_data(self, deployment_id: uuid):
+        """
+        Deletes opera session data
+        """
+        pass
+
     def update_deployment_log(self, invocation_id: uuid, inv: Invocation):
         """
         updates deployment log with deployment_id, timestamp, invocation_id, _log
@@ -160,6 +166,12 @@ class Database:
     def get_blueprints_by_user_or_project(self, username: str = None, project_domain: str = None):
         """
         Returns [blueprint_id] for every blueprint, that belongs to user or project (or both)
+        """
+        pass
+
+    def delete_deployment(self, deployment_id: uuid):
+        """
+        Deletes deployment data
         """
         pass
 
@@ -378,6 +390,27 @@ class PostgreSQL(Database):
                 'tree': json.loads(line[2])
             }
             return session_data
+
+    def delete_opera_session_data(self, deployment_id: uuid):
+        """
+        Deletes opera session data
+        """
+        stmt = sql.SQL("""delete from {session_data_table} 
+                            where deployment_id = {deployment_id}""").format(
+            session_data_table=sql.Identifier(Settings.opera_session_data_table),
+            deployment_id=sql.Literal(str(deployment_id))
+        )
+
+        success = self.execute(stmt)
+
+        if success:
+            logger.debug(
+                f'Deleted opera_session_data for deployment_id={deployment_id} from PostgreSQL database')
+        else:
+            logger.error(
+                f'Failed to delete opera_session_data for deployment_id={deployment_id} from PostgreSQL database')
+
+        return success
 
     def update_deployment_log(self, invocation_id: uuid, inv: Invocation):
         """
@@ -759,3 +792,24 @@ class PostgreSQL(Database):
                 } for line in lines
             ]
             return blueprint_list
+
+    def delete_deployment(self, deployment_id: uuid):
+        """
+        Deletes deployment data
+        """
+        stmt = sql.SQL("""delete from {invocation_table} 
+                            where deployment_id = {deployment_id}""").format(
+            invocation_table=sql.Identifier(Settings.invocation_table),
+            deployment_id=sql.Literal(str(deployment_id))
+        )
+
+        success = self.execute(stmt)
+
+        if success:
+            logger.debug(
+                f'Deleted deployment for deployment_id={deployment_id} from PostgreSQL database')
+        else:
+            logger.error(
+                f'Failed to delete deployment for deployment_id={deployment_id} from PostgreSQL database')
+
+        return success

--- a/src/opera/api/tests/test_10_deployment.py
+++ b/src/opera/api/tests/test_10_deployment.py
@@ -300,3 +300,43 @@ class TestUndeploy:
             workers=inv.workers,
             inputs={'marker': 'blah'}
         )
+
+
+class TestDeleteDeployment:
+
+    def test_still_running(self, client, mocker, generic_invocation: Invocation, patch_auth_wrapper):
+        inv = generic_invocation
+        inv.state = InvocationState.IN_PROGRESS
+        mocker.patch('opera.api.service.sqldb_service.Database.get_deployment_status', return_value=inv)
+
+        resp = client.delete(f"/deployment/{inv.deployment_id}")
+        assert resp.status_code == 403
+        assert_that(resp.json).contains('still running')
+
+    def test_fail(self, client, mocker, generic_invocation: Invocation, patch_auth_wrapper):
+        inv = generic_invocation
+        inv.deployment_id = uuid.uuid4()
+        # to pass previous operation test
+        inv.state = InvocationState.SUCCESS
+        inv.workers = 42
+
+        mocker.patch('opera.api.service.sqldb_service.Database.delete_deployment', return_value=False)
+        mocker.patch('opera.api.service.sqldb_service.Database.delete_opera_session_data', return_value=True)
+
+        resp = client.delete(f"/deployment/{inv.deployment_id}")
+        assert resp.status_code == 500
+        assert_that(resp.json).contains("Failed to delete")
+
+    def test_params(self, client, mocker, generic_invocation: Invocation, patch_auth_wrapper):
+        inv = generic_invocation
+        inv.deployment_id = uuid.uuid4()
+        # to pass previous operation test
+        inv.state = InvocationState.SUCCESS
+        inv.workers = 42
+
+        mocker.patch('opera.api.service.sqldb_service.Database.delete_deployment', return_value=True)
+        mocker.patch('opera.api.service.sqldb_service.Database.delete_opera_session_data', return_value=True)
+
+        resp = client.delete(f"/deployment/{inv.deployment_id}")
+        assert resp.status_code == 200
+        assert_that(resp.json).contains("deleted")


### PR DESCRIPTION
This PR support two features, which are important for https://github.com/SODALITE-EU/ide/issues/10:

- Flag `active` on GET /blueprint/{blueprint_id}/deployments:
    This flag allows IDE to show only active deployments. Active deployment is any deployment, that has not been successfully 
    undeployed.
- New endpoint: DELETE /deployment/{deployment_id}:
    This endpoint allows deletion of arbitrary finished deployment (deployments with status `in_progress` or `pending` are 
    excluded). This feature is useful for cleaning up failed deployments.

Closes #113 