### PR TITLE
Fix playbook for delete operation and add M30Release as a major release

### DIFF
--- a/validate_tag.sh
+++ b/validate_tag.sh
@@ -47,7 +47,7 @@ SemVarProd() {
 }
 
 MajorRelease() {
-  if [[ "$VALUE" == "M18Release" ]] || [[ "$VALUE" == "M24Release" ]] || [[ "$VALUE" == "M36Release" ]]; then
+  if [[ "$VALUE" == "M18Release" ]] || [[ "$VALUE" == "M24Release" ]] || [[ "$VALUE" == "M30Release" ]] || [[ "$VALUE" == "M36Release" ]]; then
     echo true | tr -d '\n'
   else
     echo false | tr -d '\n'

--- a/xOpera-rest-blueprint/library/util/playbooks/delete.yml
+++ b/xOpera-rest-blueprint/library/util/playbooks/delete.yml
@@ -2,5 +2,5 @@
   tasks:
     - name: Delete file
       file:
-        state: "{{ absent }}"
+        state: "absent"
         path: "{{ dest }}"


### PR DESCRIPTION
While adding Jenkinsfile to MODAK, we discovered some minor issues with the playbook for delete operation in utils library and absence of M30Release tag as a major release in the validate tags script. This PR resolves them.