### PR TITLE
Fix error handling

### DIFF
--- a/src/opera/api/controllers/deployment_controller.py
+++ b/src/opera/api/controllers/deployment_controller.py
@@ -37,6 +37,8 @@ def get_status(deployment_id):
     :rtype: Invocation
     """
     inv = invocation_service.load_invocation(deployment_id)
+    if not inv:
+        return "Job not found", 404
     return inv, 200
 
 

--- a/src/opera/api/util/xopera_util.py
+++ b/src/opera/api/util/xopera_util.py
@@ -225,7 +225,7 @@ def setup_user(locations: list, username: str, access_token: str):
             setup_user_keys(username, access_token)
 
         except Exception as e:
-            logger.warn( "An error occurred adding SSH key: " + str(e))
+            logger.warning("An error occurred adding SSH key: " + str(e))
 
 
 def create_user(username: str):
@@ -258,7 +258,7 @@ def setup_user_keys(username: str, access_token: str):
                 if vaildate_key(key):
                     add_key(key)
                 else:
-                    logger.warn("Provided key value is not a valid SSH key.")
+                    logger.warning("Provided key value is not a valid SSH key.")
 
 
 


### PR DESCRIPTION
This PR fixes bug on `/deployment/{deployment_id}/status` endpoint which sometimes returns empty response with status code 200. Fixes:
- If empty response, return 404
- If stdin or stdout files are not found, return invocation with data from DB (not None)
