### PR TITLE
Fix DB sharing issues

### DIFF
--- a/src/opera/api/cli.py
+++ b/src/opera/api/cli.py
@@ -4,7 +4,8 @@ import connexion
 
 from opera.api.log import get_logger
 from opera.api.openapi import encoder
-from opera.api.service import sqldb_service, csardb_service
+from opera.api.service import csardb_service
+from opera.api.service.sqldb_service import PostgreSQL
 from opera.api.settings import Settings
 from opera.api.util import xopera_util
 
@@ -12,12 +13,12 @@ DEBUG = os.getenv("DEBUG", "false") == "true"
 logger = get_logger(__name__)
 Settings.load_settings()
 CSAR_db = csardb_service.GitDB(**Settings.git_config)
-SQL_database = sqldb_service.connect(Settings.sql_config)
 
 
 def main():
     xopera_util.init_data()
     xopera_util.configure_ssh_keys()
+    PostgreSQL.initialize()
 
     if DEBUG:
         logger.info("Running in debug mode: flask backend.")

--- a/src/opera/api/controllers/blueprint_meta_controller.py
+++ b/src/opera/api/controllers/blueprint_meta_controller.py
@@ -1,4 +1,4 @@
-from opera.api.cli import SQL_database
+from opera.api.service.sqldb_service import PostgreSQL
 from opera.api.controllers import security_controller
 from opera.api.log import get_logger
 from opera.api.openapi.models import BlueprintVersion, GitLog, Deployment
@@ -17,7 +17,7 @@ def get_blueprint_meta(blueprint_id):  # noqa: E501
 
     :rtype: Blueprint
     """
-    data = SQL_database.get_blueprint_meta(blueprint_id)
+    data = PostgreSQL.get_blueprint_meta(blueprint_id)
     if not data:
         return "Blueprint meta not found", 404
     return BlueprintVersion.from_dict(data), 200
@@ -36,7 +36,7 @@ def get_blueprint_version_meta(blueprint_id, version_id):  # noqa: E501
 
     :rtype: Blueprint
     """
-    data = SQL_database.get_blueprint_meta(blueprint_id, version_id)
+    data = PostgreSQL.get_blueprint_meta(blueprint_id, version_id)
     if not data:
         return "Blueprint meta not found", 404
     return BlueprintVersion.from_dict(data), 200
@@ -53,7 +53,7 @@ def get_blueprint_name(blueprint_id):  # noqa: E501
 
     :rtype: str
     """
-    name = SQL_database.get_blueprint_name(blueprint_id)
+    name = PostgreSQL.get_blueprint_name(blueprint_id)
     if not name:
         return "Blueprint name not found", 404
     return name, 200
@@ -72,7 +72,7 @@ def post_blueprint_name(blueprint_id, name):  # noqa: E501
 
     :rtype: str
     """
-    if not SQL_database.update_blueprint_name(blueprint_id, name):
+    if not PostgreSQL.update_blueprint_name(blueprint_id, name):
         return f"Failed to save project data for blueprint_id={blueprint_id}", 500
     return "Successfully changed name", 201
 
@@ -90,7 +90,7 @@ def get_blueprint_deployments(blueprint_id, active=True):  # noqa: E501
 
     :rtype: List[Deployment]
     """
-    data = SQL_database.get_deployments_for_blueprint(blueprint_id, active)
+    data = PostgreSQL.get_deployments_for_blueprint(blueprint_id, active)
     if not data:
         return "Deployments not found", 404
     return [Deployment.from_dict(item) for item in data], 200
@@ -105,7 +105,7 @@ def get_git_log(blueprint_id):
 
     :rtype: List[GitLog]
     """
-    data = SQL_database.get_git_transaction_data(blueprint_id)
+    data = PostgreSQL.get_git_transaction_data(blueprint_id)
     if not data:
         return "Log not found", 404
     return [GitLog.from_dict(item) for item in data], 200

--- a/src/opera/api/controllers/deployment_controller.py
+++ b/src/opera/api/controllers/deployment_controller.py
@@ -1,4 +1,4 @@
-from opera.api.cli import SQL_database
+from opera.api.service.sqldb_service import PostgreSQL
 from opera.api.controllers import security_controller
 from opera.api.controllers.background_invocation import InvocationService
 from opera.api.controllers.background_invocation import InvocationWorkerProcess
@@ -21,7 +21,7 @@ def get_deploy_log(deployment_id):
 
     :rtype: List[Invocation]
     """
-    history = SQL_database.get_deployment_history(deployment_id)
+    history = PostgreSQL.get_deployment_history(deployment_id)
     if not history:
         return "History not found", 404
     return history, 200
@@ -59,7 +59,7 @@ def post_deploy_continue(deployment_id, workers=1, clean_state=False):
     inputs = xopera_util.get_preprocessed_inputs()
     username = security_controller.get_username()
 
-    inv = SQL_database.get_deployment_status(deployment_id)
+    inv = PostgreSQL.get_deployment_status(deployment_id)
 
     if inv.state in [InvocationState.PENDING, InvocationState.IN_PROGRESS]:
         return f"Previous operation on this deployment still running", 403
@@ -149,7 +149,7 @@ def post_undeploy(deployment_id, workers=1, force=False):
     inputs = xopera_util.get_preprocessed_inputs()
     username = security_controller.get_username()
 
-    inv = SQL_database.get_deployment_status(deployment_id)
+    inv = PostgreSQL.get_deployment_status(deployment_id)
     if not force:
         if inv.state in [InvocationState.PENDING, InvocationState.IN_PROGRESS]:
             return f"Previous operation on this deployment still running", 403
@@ -190,7 +190,7 @@ def post_update(deployment_id, blueprint_id, version_id=None, workers=1):
     inputs = xopera_util.get_preprocessed_inputs()
     username = security_controller.get_username()
 
-    inv = SQL_database.get_deployment_status(deployment_id)
+    inv = PostgreSQL.get_deployment_status(deployment_id)
     if inv.state in [InvocationState.PENDING, InvocationState.IN_PROGRESS]:
         return f"Previous operation on this deployment still running", 403
 
@@ -223,13 +223,13 @@ def delete_deployment(deployment_id, force=False):
     :rtype: str
     """
 
-    inv = SQL_database.get_deployment_status(deployment_id)
+    inv = PostgreSQL.get_deployment_status(deployment_id)
     if not force:
         if inv.state in [InvocationState.PENDING, InvocationState.IN_PROGRESS]:
             return f"Previous operation on this deployment still running", 403
 
-    success_deployment = SQL_database.delete_deployment(deployment_id)
-    success_session_data = SQL_database.delete_opera_session_data(deployment_id)
+    success_deployment = PostgreSQL.delete_deployment(deployment_id)
+    success_session_data = PostgreSQL.delete_opera_session_data(deployment_id)
     if not (success_deployment and success_session_data):
         return "Failed to delete deployment", 500
 

--- a/src/opera/api/controllers/security_controller.py
+++ b/src/opera/api/controllers/security_controller.py
@@ -6,7 +6,8 @@ from base64 import b64encode
 import connexion
 import requests
 
-from opera.api.cli import CSAR_db, SQL_database
+from opera.api.cli import CSAR_db
+from opera.api.service.sqldb_service import PostgreSQL
 from opera.api.settings import Settings
 
 # use connection pool for OAuth tokeninfo
@@ -114,11 +115,11 @@ def check_role_auth_blueprint(func):
             return f"Authorization configuration error", 401
 
         version_id = kwargs.get("version_id")
-        if not SQL_database.version_exists(blueprint_id, version_id) and not CSAR_db.version_exists(blueprint_id,
-                                                                                                    version_id):
+        if not PostgreSQL.version_exists(blueprint_id, version_id) and not CSAR_db.version_exists(blueprint_id,
+                                                                                                  version_id):
             return f"Did not find blueprint with id: {blueprint_id} and version_id: {version_id or 'any'}", 404
 
-        project_domain = SQL_database.get_project_domain(blueprint_id)
+        project_domain = PostgreSQL.get_project_domain(blueprint_id)
         if project_domain and not check_roles(project_domain):
             return f"Unauthorized request for project: {project_domain}", 401
 
@@ -134,7 +135,7 @@ def check_role_auth_project_domain(func):
         if not blueprint_id:
             return f"Authorization configuration error", 401
 
-        project_domain = SQL_database.get_project_domain(blueprint_id)
+        project_domain = PostgreSQL.get_project_domain(blueprint_id)
         if project_domain and not check_roles(project_domain):
             return f"Unauthorized request for project: {project_domain}", 401
 
@@ -150,15 +151,15 @@ def check_role_auth_deployment(func):
         if not deployment_id:
             return f"Authorization configuration error", 401
 
-        inv = SQL_database.get_deployment_status(deployment_id)
+        inv = PostgreSQL.get_deployment_status(deployment_id)
         if not inv:
             return f"Deployment with id: {deployment_id} does not exist", 404
 
-        if not SQL_database.version_exists(inv.blueprint_id, inv.version_id) and not CSAR_db.version_exists(
+        if not PostgreSQL.version_exists(inv.blueprint_id, inv.version_id) and not CSAR_db.version_exists(
                 inv.blueprint_id, inv.version_id):
             return f"Did not find blueprint with id: {inv.blueprint_id} and version_id: {inv.version_id or 'any'}", 404
 
-        project_domain = SQL_database.get_project_domain(inv.blueprint_id)
+        project_domain = PostgreSQL.get_project_domain(inv.blueprint_id)
         if project_domain and not check_roles(project_domain):
             return f"Unauthorized request for project: {project_domain}", 401
 

--- a/src/opera/api/settings/settings.py
+++ b/src/opera/api/settings/settings.py
@@ -24,16 +24,12 @@ class Settings:
     # maximum number of invocations at the same time
     invocation_service_workers = 10
 
-    # sql_database config
+    # PostgreSQL config
     sql_config = None
     invocation_table = 'invocation'
     blueprint_table = 'blueprint'
     git_log_table = 'git_log'
     opera_session_data_table = 'opera_session_data'
-
-    # OfflineStorage database (alternative to sql_database) config
-    USE_OFFLINE_STORAGE = False
-    offline_storage = None
 
     # gitCsarDB config
     git_config = None
@@ -58,7 +54,6 @@ class Settings:
         Settings.STDFILE_DIR = f"{Settings.API_WORKDIR}/in_progress"
         Settings.INVOCATION_DIR = f"{Settings.API_WORKDIR}/invocations"
         Settings.DEPLOYMENT_DIR = f"{Settings.API_WORKDIR}/deployment_dir"
-        Settings.offline_storage = Path(Settings.API_WORKDIR) / 'storage'
         Settings.workdir = Path(Settings.API_WORKDIR) / "git_db/mockConnector"
         Settings.secure_workdir = os.getenv("XOPERA_SECURE_WORKDIR", "True").lower() == "true"
 

--- a/src/opera/api/tests/test_18_validate.py
+++ b/src/opera/api/tests/test_18_validate.py
@@ -5,7 +5,7 @@ from assertpy import assert_that
 
 class TestValidateExisting:
 
-    def test_no_blueprint(self, client, mocker):
+    def test_no_blueprint(self, client, mocker, patch_db):
         blueprint_id = uuid.uuid4()
         mock_version_exists = mocker.MagicMock(name='version_exists', return_value=False)
         mocker.patch('opera.api.service.csardb_service.GitDB.version_exists', new=mock_version_exists)
@@ -14,7 +14,7 @@ class TestValidateExisting:
         assert resp.status_code == 404
         mock_version_exists.assert_called_with(str(blueprint_id), None)
 
-    def test_exception(self, client, mocker):
+    def test_exception(self, client, mocker, patch_db):
         blueprint_id = uuid.uuid4()
         mocker.patch('opera.api.service.csardb_service.GitDB.version_exists', return_value=True)
         mock_validate = mocker.MagicMock(name='validate',
@@ -30,7 +30,7 @@ class TestValidateExisting:
         assert_that(resp.json['error']).contains("Exception stacktrace")
         mock_validate.assert_called_with(str(blueprint_id), None, None)
 
-    def test_ok(self, client, mocker, inputs_1):
+    def test_ok(self, client, mocker, inputs_1, patch_db):
         blueprint_token = uuid.uuid4()
         mocker.patch('opera.api.service.csardb_service.GitDB.version_exists', return_value=True)
         mock_validate = mocker.MagicMock(name='validate', return_value=None)
@@ -45,7 +45,7 @@ class TestValidateExisting:
 
 class TestValidateExistingVersion:
 
-    def test_no_blueprint(self, client, mocker):
+    def test_no_blueprint(self, client, mocker, patch_db):
         blueprint_id = uuid.uuid4()
         version_id = 'v1.0'
         mock_version_exists = mocker.MagicMock(name='version_exists', return_value=False)
@@ -55,7 +55,7 @@ class TestValidateExistingVersion:
         assert resp.status_code == 404
         mock_version_exists.assert_called_with(str(blueprint_id), version_id)
 
-    def test_exception(self, client, mocker):
+    def test_exception(self, client, mocker, patch_db):
         blueprint_id = uuid.uuid4()
         version_id = 'v1.0'
         mocker.patch('opera.api.service.csardb_service.GitDB.version_exists', return_value=True)
@@ -71,7 +71,7 @@ class TestValidateExistingVersion:
         assert_that(resp.json['error']).contains("Exception stacktrace")
         mock_validate.assert_called_with(str(blueprint_id), version_id, None)
 
-    def test_ok(self, client, mocker, inputs_1):
+    def test_ok(self, client, mocker, inputs_1, patch_db):
         blueprint_token = uuid.uuid4()
         version_id = 'v1.0'
         mocker.patch('opera.api.service.csardb_service.GitDB.version_exists', return_value=True)


### PR DESCRIPTION
This PR changes DB interaction. Now DB every process, that needs DB connection, creates a new one and closes it afterwards. No connection is shared among processes.

In case of DB being temporarily down, xOpera will also be able to restore a connection once Database is available.

Closes #131 #98 